### PR TITLE
[#68] Create abstract classes/interfaces to encapsulate common behaviors

### DIFF
--- a/src/main/java/seedu/address/logic/abstractcommand/AddCommand.java
+++ b/src/main/java/seedu/address/logic/abstractcommand/AddCommand.java
@@ -1,0 +1,36 @@
+package seedu.address.logic.abstractcommand;
+
+import static java.util.Objects.requireNonNull;
+
+import seedu.address.logic.commands.CommandResult;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.item.Item;
+import seedu.address.model.item.ItemManagerWithFilteredList;
+
+public abstract class AddCommand<T extends Item> extends ItemCommand<T> {
+
+    private final T itemToAdd;
+
+    public AddCommand(T item) {
+        requireNonNull(item);
+        itemToAdd = item;
+    }
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+
+        ItemManagerWithFilteredList<T> managerAndList = getManagerAndList(model);
+        if (managerAndList.hasItem(itemToAdd)) {
+            throw new CommandException(getDuplicateItemMessage());
+        }
+
+        managerAndList.addItem(itemToAdd);
+        return new CommandResult(getSuccessMessage());
+    }
+
+    abstract String getDuplicateItemMessage();
+
+    abstract String getSuccessMessage();
+}

--- a/src/main/java/seedu/address/logic/abstractcommand/AddCommand.java
+++ b/src/main/java/seedu/address/logic/abstractcommand/AddCommand.java
@@ -39,7 +39,7 @@ public abstract class AddCommand<T extends Item> extends ItemCommand<T> {
         }
 
         managerAndList.addItem(itemToAdd);
-        return new CommandResult(getSuccessMessage());
+        return new CommandResult(getSuccessMessage(itemToAdd));
     }
 
     /**
@@ -50,5 +50,5 @@ public abstract class AddCommand<T extends Item> extends ItemCommand<T> {
     /**
      * Returns the message to be displayed when the item is successfully added to the model.
      */
-    public abstract String getSuccessMessage();
+    public abstract String getSuccessMessage(T itemToAdd);
 }

--- a/src/main/java/seedu/address/logic/abstractcommand/AddCommand.java
+++ b/src/main/java/seedu/address/logic/abstractcommand/AddCommand.java
@@ -45,10 +45,10 @@ public abstract class AddCommand<T extends Item> extends ItemCommand<T> {
     /**
      * Returns the message to be displayed when the item being added is a duplicate.
      */
-    abstract String getDuplicateItemMessage();
+    public abstract String getDuplicateItemMessage();
 
     /**
      * Returns the message to be displayed when the item is successfully added to the model.
      */
-    abstract String getSuccessMessage();
+    public abstract String getSuccessMessage();
 }

--- a/src/main/java/seedu/address/logic/abstractcommand/AddCommand.java
+++ b/src/main/java/seedu/address/logic/abstractcommand/AddCommand.java
@@ -10,10 +10,18 @@ import seedu.address.model.Model;
 import seedu.address.model.item.Item;
 import seedu.address.model.item.ItemManagerWithFilteredList;
 
+/**
+ * Abstract command to add an {@code Item} to the model.
+ *
+ * @param <T> the type of {@code Item} being added, which must extend {@link Item}.
+ */
 public abstract class AddCommand<T extends Item> extends ItemCommand<T> {
 
     private final T itemToAdd;
 
+    /**
+     * Creates an AddCommand to add the specified {@code item}
+     */
     public AddCommand(T item,
                       Function<Model, ItemManagerWithFilteredList<T>> managerAndListGetter) {
         super(managerAndListGetter);
@@ -34,7 +42,13 @@ public abstract class AddCommand<T extends Item> extends ItemCommand<T> {
         return new CommandResult(getSuccessMessage());
     }
 
+    /**
+     * Returns the message to be displayed when the item being added is a duplicate.
+     */
     abstract String getDuplicateItemMessage();
 
+    /**
+     * Returns the message to be displayed when the item is successfully added to the model.
+     */
     abstract String getSuccessMessage();
 }

--- a/src/main/java/seedu/address/logic/abstractcommand/AddCommand.java
+++ b/src/main/java/seedu/address/logic/abstractcommand/AddCommand.java
@@ -2,6 +2,8 @@ package seedu.address.logic.abstractcommand;
 
 import static java.util.Objects.requireNonNull;
 
+import java.util.function.Function;
+
 import seedu.address.logic.commands.CommandResult;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
@@ -12,7 +14,9 @@ public abstract class AddCommand<T extends Item> extends ItemCommand<T> {
 
     private final T itemToAdd;
 
-    public AddCommand(T item) {
+    public AddCommand(T item,
+                      Function<Model, ItemManagerWithFilteredList<T>> managerAndListGetter) {
+        super(managerAndListGetter);
         requireNonNull(item);
         itemToAdd = item;
     }
@@ -21,7 +25,7 @@ public abstract class AddCommand<T extends Item> extends ItemCommand<T> {
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
 
-        ItemManagerWithFilteredList<T> managerAndList = getManagerAndList(model);
+        ItemManagerWithFilteredList<T> managerAndList = managerAndListGetter.apply(model);
         if (managerAndList.hasItem(itemToAdd)) {
             throw new CommandException(getDuplicateItemMessage());
         }

--- a/src/main/java/seedu/address/logic/abstractcommand/ClearCommand.java
+++ b/src/main/java/seedu/address/logic/abstractcommand/ClearCommand.java
@@ -2,6 +2,8 @@ package seedu.address.logic.abstractcommand;
 
 import static java.util.Objects.requireNonNull;
 
+import java.util.function.Function;
+
 import seedu.address.logic.commands.CommandResult;
 import seedu.address.model.Model;
 import seedu.address.model.item.Item;
@@ -9,9 +11,13 @@ import seedu.address.model.item.ItemManager;
 import seedu.address.model.item.ItemManagerWithFilteredList;
 
 public abstract class ClearCommand<T extends Item> extends ItemCommand<T> {
+    public ClearCommand(Function<Model, ItemManagerWithFilteredList<T>> managerAndListGetter) {
+        super(managerAndListGetter);
+    }
+
     public CommandResult execute(Model model) {
         requireNonNull(model);
-        ItemManagerWithFilteredList<T> managerAndList = getManagerAndList(model);
+        ItemManagerWithFilteredList<T> managerAndList = managerAndListGetter.apply(model);
         managerAndList.setItemManager(getEmptyItemManager());
         return new CommandResult(getSuccessMessage());
     }

--- a/src/main/java/seedu/address/logic/abstractcommand/ClearCommand.java
+++ b/src/main/java/seedu/address/logic/abstractcommand/ClearCommand.java
@@ -1,0 +1,22 @@
+package seedu.address.logic.abstractcommand;
+
+import static java.util.Objects.requireNonNull;
+
+import seedu.address.logic.commands.CommandResult;
+import seedu.address.model.Model;
+import seedu.address.model.item.Item;
+import seedu.address.model.item.ItemManager;
+import seedu.address.model.item.ItemManagerWithFilteredList;
+
+public abstract class ClearCommand<T extends Item> extends ItemCommand<T> {
+    public CommandResult execute(Model model) {
+        requireNonNull(model);
+        ItemManagerWithFilteredList<T> managerAndList = getManagerAndList(model);
+        managerAndList.setItemManager(getEmptyItemManager());
+        return new CommandResult(getSuccessMessage());
+    }
+
+    abstract ItemManager<T> getEmptyItemManager();
+
+    abstract String getSuccessMessage();
+}

--- a/src/main/java/seedu/address/logic/abstractcommand/ClearCommand.java
+++ b/src/main/java/seedu/address/logic/abstractcommand/ClearCommand.java
@@ -3,6 +3,7 @@ package seedu.address.logic.abstractcommand;
 import static java.util.Objects.requireNonNull;
 
 import java.util.function.Function;
+import java.util.function.Supplier;
 
 import seedu.address.logic.commands.CommandResult;
 import seedu.address.model.Model;
@@ -10,19 +11,33 @@ import seedu.address.model.item.Item;
 import seedu.address.model.item.ItemManager;
 import seedu.address.model.item.ItemManagerWithFilteredList;
 
+/**
+ * Abstract command to clear the list of {@code Item} objects in the model.
+ *
+ * @param <T> the type of {@code Item} being cleared, which must extend {@link Item}.
+ */
 public abstract class ClearCommand<T extends Item> extends ItemCommand<T> {
-    public ClearCommand(Function<Model, ItemManagerWithFilteredList<T>> managerAndListGetter) {
+    protected final Supplier<ItemManager<T>> emptyItemManagerSupplier;
+
+    /**
+     * Creates a {@code ClearCommand} to clear the item list in the model.
+     */
+    public ClearCommand(Function<Model, ItemManagerWithFilteredList<T>> managerAndListGetter,
+                        Supplier<ItemManager<T>> emptyItemManagerSupplier) {
         super(managerAndListGetter);
+        this.emptyItemManagerSupplier = emptyItemManagerSupplier;
     }
 
+    @Override
     public CommandResult execute(Model model) {
         requireNonNull(model);
         ItemManagerWithFilteredList<T> managerAndList = managerAndListGetter.apply(model);
-        managerAndList.setItemManager(getEmptyItemManager());
+        managerAndList.setItemManager(emptyItemManagerSupplier.get());
         return new CommandResult(getSuccessMessage());
     }
 
-    abstract ItemManager<T> getEmptyItemManager();
-
+    /**
+     * Returns the success message to be displayed when the item list is cleared.
+     */
     abstract String getSuccessMessage();
 }

--- a/src/main/java/seedu/address/logic/abstractcommand/ClearCommand.java
+++ b/src/main/java/seedu/address/logic/abstractcommand/ClearCommand.java
@@ -39,5 +39,5 @@ public abstract class ClearCommand<T extends Item> extends ItemCommand<T> {
     /**
      * Returns the success message to be displayed when the item list is cleared.
      */
-    abstract String getSuccessMessage();
+    public abstract String getSuccessMessage();
 }

--- a/src/main/java/seedu/address/logic/abstractcommand/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/abstractcommand/DeleteCommand.java
@@ -3,6 +3,7 @@ package seedu.address.logic.abstractcommand;
 import static java.util.Objects.requireNonNull;
 
 import java.util.List;
+import java.util.function.Function;
 
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.CommandResult;
@@ -14,14 +15,17 @@ import seedu.address.model.item.ItemManagerWithFilteredList;
 public abstract class DeleteCommand<T extends Item> extends ItemCommand<T> {
     private final Index targetIndex;
 
-    public DeleteCommand(Index targetIndex) {
+    public DeleteCommand(Index targetIndex,
+                         Function<Model, ItemManagerWithFilteredList<T>> managerAndListGetter) {
+        super(managerAndListGetter);
+        requireNonNull(targetIndex);
         this.targetIndex = targetIndex;
     }
 
     @Override
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
-        ItemManagerWithFilteredList<T> managerAndList = getManagerAndList(model);
+        ItemManagerWithFilteredList<T> managerAndList = managerAndListGetter.apply(model);
         List<T> lastShownList = managerAndList.getFilteredItemsList();
 
         if (targetIndex.getZeroBased() >= lastShownList.size()) {

--- a/src/main/java/seedu/address/logic/abstractcommand/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/abstractcommand/DeleteCommand.java
@@ -1,0 +1,39 @@
+package seedu.address.logic.abstractcommand;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.List;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.CommandResult;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.item.Item;
+import seedu.address.model.item.ItemManagerWithFilteredList;
+
+public abstract class DeleteCommand<T extends Item> extends ItemCommand<T> {
+    private final Index targetIndex;
+
+    public DeleteCommand(Index targetIndex) {
+        this.targetIndex = targetIndex;
+    }
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+        ItemManagerWithFilteredList<T> managerAndList = getManagerAndList(model);
+        List<T> lastShownList = managerAndList.getFilteredItemsList();
+
+        if (targetIndex.getZeroBased() >= lastShownList.size()) {
+            throw new CommandException(getInvalidIndexMessage());
+        }
+
+        T itemToDelete = lastShownList.get(targetIndex.getZeroBased());
+        managerAndList.deleteItem(itemToDelete);
+        return new CommandResult(getSuccessMessage(itemToDelete));
+    }
+
+    abstract String getInvalidIndexMessage();
+
+    abstract String getSuccessMessage(T item);
+}

--- a/src/main/java/seedu/address/logic/abstractcommand/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/abstractcommand/DeleteCommand.java
@@ -12,9 +12,21 @@ import seedu.address.model.Model;
 import seedu.address.model.item.Item;
 import seedu.address.model.item.ItemManagerWithFilteredList;
 
+/**
+ * Abstract command to delete an {@code Item} from the model based on a given index.
+ *
+ * @param <T> the type of {@code Item} being deleted, which must extend {@link Item}.
+ */
 public abstract class DeleteCommand<T extends Item> extends ItemCommand<T> {
     private final Index targetIndex;
 
+    /**
+     * Creates a {@code DeleteCommand} to delete an {@code Item} at the specified
+     * {@code targetIndex}.
+     *
+     * @throws NullPointerException if {@code targetIndex} or {@code managerAndListGetter} is
+     *                              {@code null}.
+     */
     public DeleteCommand(Index targetIndex,
                          Function<Model, ItemManagerWithFilteredList<T>> managerAndListGetter) {
         super(managerAndListGetter);
@@ -37,7 +49,13 @@ public abstract class DeleteCommand<T extends Item> extends ItemCommand<T> {
         return new CommandResult(getSuccessMessage(itemToDelete));
     }
 
+    /**
+     * Returns the message to be displayed when the provided {@code targetIndex} is invalid.
+     */
     abstract String getInvalidIndexMessage();
 
+    /**
+     * Returns the success message to be displayed when an {@code Item} is successfully deleted.
+     */
     abstract String getSuccessMessage(T item);
 }

--- a/src/main/java/seedu/address/logic/abstractcommand/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/abstractcommand/DeleteCommand.java
@@ -52,10 +52,10 @@ public abstract class DeleteCommand<T extends Item> extends ItemCommand<T> {
     /**
      * Returns the message to be displayed when the provided {@code targetIndex} is invalid.
      */
-    abstract String getInvalidIndexMessage();
+    public abstract String getInvalidIndexMessage();
 
     /**
      * Returns the success message to be displayed when an {@code Item} is successfully deleted.
      */
-    abstract String getSuccessMessage(T item);
+    public abstract String getSuccessMessage(T item);
 }

--- a/src/main/java/seedu/address/logic/abstractcommand/DisplayInformationCommand.java
+++ b/src/main/java/seedu/address/logic/abstractcommand/DisplayInformationCommand.java
@@ -53,10 +53,10 @@ public abstract class DisplayInformationCommand<T extends Item> extends ItemComm
     /**
      * Returns the message to be displayed when the provided {@code index} is invalid.
      */
-    abstract String getInvalidIndexMessage();
+    public abstract String getInvalidIndexMessage();
 
     /**
      * Returns the information message to be displayed for the given {@code item}.
      */
-    abstract String getInformationMessage(T editedItem);
+    public abstract String getInformationMessage(T editedItem);
 }

--- a/src/main/java/seedu/address/logic/abstractcommand/DisplayInformationCommand.java
+++ b/src/main/java/seedu/address/logic/abstractcommand/DisplayInformationCommand.java
@@ -1,0 +1,39 @@
+package seedu.address.logic.abstractcommand;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.List;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.CommandResult;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.item.Item;
+import seedu.address.model.item.ItemManagerWithFilteredList;
+
+public abstract class DisplayInformationCommand<T extends Item> extends ItemCommand<T> {
+    private final Index index;
+
+    public DisplayInformationCommand(Index index) {
+        requireNonNull(index);
+        this.index = index;
+    }
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+        ItemManagerWithFilteredList<T> managerAndList = getManagerAndList(model);
+        List<T> lastShownList = managerAndList.getFilteredItemsList();
+
+        if (index.getZeroBased() >= lastShownList.size()) {
+            throw new CommandException(getInvalidIndexMessage());
+        }
+
+        T itemToDisplay = lastShownList.get(index.getZeroBased());
+        return new CommandResult(getInformationMessage(itemToDisplay));
+    }
+
+    abstract String getInvalidIndexMessage();
+
+    abstract String getInformationMessage(T editedItem);
+}

--- a/src/main/java/seedu/address/logic/abstractcommand/DisplayInformationCommand.java
+++ b/src/main/java/seedu/address/logic/abstractcommand/DisplayInformationCommand.java
@@ -58,5 +58,5 @@ public abstract class DisplayInformationCommand<T extends Item> extends ItemComm
     /**
      * Returns the information message to be displayed for the given {@code item}.
      */
-    public abstract String getInformationMessage(T editedItem);
+    public abstract String getInformationMessage(T itemToDisplay);
 }

--- a/src/main/java/seedu/address/logic/abstractcommand/DisplayInformationCommand.java
+++ b/src/main/java/seedu/address/logic/abstractcommand/DisplayInformationCommand.java
@@ -12,11 +12,25 @@ import seedu.address.model.Model;
 import seedu.address.model.item.Item;
 import seedu.address.model.item.ItemManagerWithFilteredList;
 
+/**
+ * Abstract command to display information about an {@code Item} from the model based on a given
+ * index.
+ *
+ * @param <T> the type of {@code Item} whose information is being displayed, which must extend
+ *            {@link Item}.
+ */
 public abstract class DisplayInformationCommand<T extends Item> extends ItemCommand<T> {
     private final Index index;
 
+    /**
+     * Creates a {@code DisplayInformationCommand} to display information of the {@code Item} at the
+     * specified {@code index}.
+     *
+     * @throws NullPointerException if {@code index} or {@code managerAndListGetter} is
+     *                              {@code null}.
+     */
     public DisplayInformationCommand(Index index, Function<Model,
-                ItemManagerWithFilteredList<T>> managerAndListGetter) {
+            ItemManagerWithFilteredList<T>> managerAndListGetter) {
         super(managerAndListGetter);
         requireNonNull(index);
         this.index = index;
@@ -36,7 +50,13 @@ public abstract class DisplayInformationCommand<T extends Item> extends ItemComm
         return new CommandResult(getInformationMessage(itemToDisplay));
     }
 
+    /**
+     * Returns the message to be displayed when the provided {@code index} is invalid.
+     */
     abstract String getInvalidIndexMessage();
 
+    /**
+     * Returns the information message to be displayed for the given {@code item}.
+     */
     abstract String getInformationMessage(T editedItem);
 }

--- a/src/main/java/seedu/address/logic/abstractcommand/DisplayInformationCommand.java
+++ b/src/main/java/seedu/address/logic/abstractcommand/DisplayInformationCommand.java
@@ -3,6 +3,7 @@ package seedu.address.logic.abstractcommand;
 import static java.util.Objects.requireNonNull;
 
 import java.util.List;
+import java.util.function.Function;
 
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.CommandResult;
@@ -14,7 +15,9 @@ import seedu.address.model.item.ItemManagerWithFilteredList;
 public abstract class DisplayInformationCommand<T extends Item> extends ItemCommand<T> {
     private final Index index;
 
-    public DisplayInformationCommand(Index index) {
+    public DisplayInformationCommand(Index index, Function<Model,
+                ItemManagerWithFilteredList<T>> managerAndListGetter) {
+        super(managerAndListGetter);
         requireNonNull(index);
         this.index = index;
     }
@@ -22,7 +25,7 @@ public abstract class DisplayInformationCommand<T extends Item> extends ItemComm
     @Override
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
-        ItemManagerWithFilteredList<T> managerAndList = getManagerAndList(model);
+        ItemManagerWithFilteredList<T> managerAndList = managerAndListGetter.apply(model);
         List<T> lastShownList = managerAndList.getFilteredItemsList();
 
         if (index.getZeroBased() >= lastShownList.size()) {

--- a/src/main/java/seedu/address/logic/abstractcommand/EditCommand.java
+++ b/src/main/java/seedu/address/logic/abstractcommand/EditCommand.java
@@ -63,20 +63,20 @@ public abstract class EditCommand<T extends Item> extends ItemCommand<T> {
     /**
      * Creates an edited version of the given item to be applied to the list.
      */
-    abstract T createEditedItem(T itemToEdit);
+    public abstract T createEditedItem(T itemToEdit);
 
     /**
      * Returns the message to be displayed when the provided index is invalid.
      */
-    abstract String getInvalidIndexMessage();
+    public abstract String getInvalidIndexMessage();
 
     /**
      * Returns the message to be displayed when the edited item is a duplicate of an existing item.
      */
-    abstract String getDuplicateMessage();
+    public abstract String getDuplicateMessage();
 
     /**
      * Returns the success message to be displayed after successfully editing the item.
      */
-    abstract String getSuccessMessage(T editedItem);
+    public abstract String getSuccessMessage(T editedItem);
 }

--- a/src/main/java/seedu/address/logic/abstractcommand/EditCommand.java
+++ b/src/main/java/seedu/address/logic/abstractcommand/EditCommand.java
@@ -1,0 +1,53 @@
+package seedu.address.logic.abstractcommand;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.List;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.CommandResult;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.item.Item;
+import seedu.address.model.item.ItemManagerWithFilteredList;
+
+public abstract class EditCommand<T extends Item> extends ItemCommand<T> {
+    private final Index index;
+
+    public EditCommand(Index index) {
+        requireNonNull(index);
+        this.index = index;
+    }
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+        ItemManagerWithFilteredList<T> managerAndList = getManagerAndList(model);
+        List<T> lastShownList = managerAndList.getFilteredItemsList();
+
+        if (index.getZeroBased() >= lastShownList.size()) {
+            throw new CommandException(getInvalidIndexMessage());
+        }
+
+        T itemToEdit = lastShownList.get(index.getZeroBased());
+        T editedItem = createEditedItem(itemToEdit);
+
+        if (!isDuplicate(itemToEdit, editedItem) && managerAndList.hasItem(editedItem)) {
+            throw new CommandException(getDuplicateMessage());
+        }
+
+        managerAndList.setItem(itemToEdit, editedItem);
+        managerAndList.showAllItems();
+        return new CommandResult(getSuccessMessage(editedItem));
+    }
+
+    abstract T createEditedItem(T itemToEdit);
+
+    abstract boolean isDuplicate(T itemToEdit, T editedItem);
+
+    abstract String getInvalidIndexMessage();
+
+    abstract String getDuplicateMessage();
+
+    abstract String getSuccessMessage(T editedItem);
+}

--- a/src/main/java/seedu/address/logic/abstractcommand/EditCommand.java
+++ b/src/main/java/seedu/address/logic/abstractcommand/EditCommand.java
@@ -14,11 +14,21 @@ import seedu.address.model.item.DuplicateChecker;
 import seedu.address.model.item.Item;
 import seedu.address.model.item.ItemManagerWithFilteredList;
 
+/**
+ * Abstract command for editing an {@code Item} in the model at a specified index.
+ *
+ * @param <T> the type of {@code Item} being edited, which must extend {@link Item}.
+ */
 public abstract class EditCommand<T extends Item> extends ItemCommand<T> {
     private final Index index;
-
     private final DuplicateChecker<T> duplicateChecker;
 
+    /**
+     * Creates an {@code EditCommand} to edit an item at the specified {@code index}.
+     *
+     * @throws NullPointerException if {@code index}, {@code managerAndListGetter}, or
+     *                               {@code duplicateChecker} is {@code null}.
+     */
     public EditCommand(Index index,
                        Function<Model, ItemManagerWithFilteredList<T>> managerAndListGetter,
                        DuplicateChecker<T> duplicateChecker) {
@@ -50,11 +60,23 @@ public abstract class EditCommand<T extends Item> extends ItemCommand<T> {
         return new CommandResult(getSuccessMessage(editedItem));
     }
 
+    /**
+     * Creates an edited version of the given item to be applied to the list.
+     */
     abstract T createEditedItem(T itemToEdit);
 
+    /**
+     * Returns the message to be displayed when the provided index is invalid.
+     */
     abstract String getInvalidIndexMessage();
 
+    /**
+     * Returns the message to be displayed when the edited item is a duplicate of an existing item.
+     */
     abstract String getDuplicateMessage();
 
+    /**
+     * Returns the success message to be displayed after successfully editing the item.
+     */
     abstract String getSuccessMessage(T editedItem);
 }

--- a/src/main/java/seedu/address/logic/abstractcommand/EditCommand.java
+++ b/src/main/java/seedu/address/logic/abstractcommand/EditCommand.java
@@ -1,28 +1,37 @@
 package seedu.address.logic.abstractcommand;
 
 import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
 import java.util.List;
+import java.util.function.Function;
 
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.CommandResult;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
+import seedu.address.model.item.DuplicateChecker;
 import seedu.address.model.item.Item;
 import seedu.address.model.item.ItemManagerWithFilteredList;
 
 public abstract class EditCommand<T extends Item> extends ItemCommand<T> {
     private final Index index;
 
-    public EditCommand(Index index) {
-        requireNonNull(index);
+    private final DuplicateChecker<T> duplicateChecker;
+
+    public EditCommand(Index index,
+                       Function<Model, ItemManagerWithFilteredList<T>> managerAndListGetter,
+                       DuplicateChecker<T> duplicateChecker) {
+        super(managerAndListGetter);
+        requireAllNonNull(index, duplicateChecker);
         this.index = index;
+        this.duplicateChecker = duplicateChecker;
     }
 
     @Override
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
-        ItemManagerWithFilteredList<T> managerAndList = getManagerAndList(model);
+        ItemManagerWithFilteredList<T> managerAndList = managerAndListGetter.apply(model);
         List<T> lastShownList = managerAndList.getFilteredItemsList();
 
         if (index.getZeroBased() >= lastShownList.size()) {
@@ -32,7 +41,7 @@ public abstract class EditCommand<T extends Item> extends ItemCommand<T> {
         T itemToEdit = lastShownList.get(index.getZeroBased());
         T editedItem = createEditedItem(itemToEdit);
 
-        if (!isDuplicate(itemToEdit, editedItem) && managerAndList.hasItem(editedItem)) {
+        if (!duplicateChecker.check(itemToEdit, editedItem) && managerAndList.hasItem(editedItem)) {
             throw new CommandException(getDuplicateMessage());
         }
 
@@ -42,8 +51,6 @@ public abstract class EditCommand<T extends Item> extends ItemCommand<T> {
     }
 
     abstract T createEditedItem(T itemToEdit);
-
-    abstract boolean isDuplicate(T itemToEdit, T editedItem);
 
     abstract String getInvalidIndexMessage();
 

--- a/src/main/java/seedu/address/logic/abstractcommand/FindCommand.java
+++ b/src/main/java/seedu/address/logic/abstractcommand/FindCommand.java
@@ -1,0 +1,29 @@
+package seedu.address.logic.abstractcommand;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.function.Predicate;
+
+import seedu.address.logic.commands.CommandResult;
+import seedu.address.model.Model;
+import seedu.address.model.item.Item;
+import seedu.address.model.item.ItemManagerWithFilteredList;
+
+public abstract class FindCommand<T extends Item> extends ItemCommand<T> {
+    private final Predicate<T> predicate;
+
+    public FindCommand(Predicate<T> predicate) {
+        this.predicate = predicate;
+    }
+
+    @Override
+    public CommandResult execute(Model model) {
+        requireNonNull(model);
+        ItemManagerWithFilteredList<T> managerAndList = getManagerAndList(model);
+        managerAndList.updateFilteredItemsList(predicate);
+        return new CommandResult(
+                getResultOverviewMessage(managerAndList.getFilteredItemsList().size()));
+    }
+
+    abstract String getResultOverviewMessage(int numberOfResults);
+}

--- a/src/main/java/seedu/address/logic/abstractcommand/FindCommand.java
+++ b/src/main/java/seedu/address/logic/abstractcommand/FindCommand.java
@@ -2,6 +2,7 @@ package seedu.address.logic.abstractcommand;
 
 import static java.util.Objects.requireNonNull;
 
+import java.util.function.Function;
 import java.util.function.Predicate;
 
 import seedu.address.logic.commands.CommandResult;
@@ -12,14 +13,17 @@ import seedu.address.model.item.ItemManagerWithFilteredList;
 public abstract class FindCommand<T extends Item> extends ItemCommand<T> {
     private final Predicate<T> predicate;
 
-    public FindCommand(Predicate<T> predicate) {
+    public FindCommand(Predicate<T> predicate,
+                       Function<Model, ItemManagerWithFilteredList<T>> managerAndListGetter) {
+        super(managerAndListGetter);
+        requireNonNull(predicate);
         this.predicate = predicate;
     }
 
     @Override
     public CommandResult execute(Model model) {
         requireNonNull(model);
-        ItemManagerWithFilteredList<T> managerAndList = getManagerAndList(model);
+        ItemManagerWithFilteredList<T> managerAndList = managerAndListGetter.apply(model);
         managerAndList.updateFilteredItemsList(predicate);
         return new CommandResult(
                 getResultOverviewMessage(managerAndList.getFilteredItemsList().size()));

--- a/src/main/java/seedu/address/logic/abstractcommand/FindCommand.java
+++ b/src/main/java/seedu/address/logic/abstractcommand/FindCommand.java
@@ -10,9 +10,20 @@ import seedu.address.model.Model;
 import seedu.address.model.item.Item;
 import seedu.address.model.item.ItemManagerWithFilteredList;
 
+/**
+ * Abstract command for finding items in the model that match a given {@code predicate}.
+ *
+ * @param <T> the type of {@code Item} being searched for, which must extend {@link Item}.
+ */
 public abstract class FindCommand<T extends Item> extends ItemCommand<T> {
     private final Predicate<T> predicate;
 
+    /**
+     * Creates a {@code FindCommand} to find items that match the given {@code predicate}.
+     *
+     * @throws NullPointerException if {@code predicate} or {@code managerAndListGetter} is
+     *                              {@code null}.
+     */
     public FindCommand(Predicate<T> predicate,
                        Function<Model, ItemManagerWithFilteredList<T>> managerAndListGetter) {
         super(managerAndListGetter);
@@ -29,5 +40,9 @@ public abstract class FindCommand<T extends Item> extends ItemCommand<T> {
                 getResultOverviewMessage(managerAndList.getFilteredItemsList().size()));
     }
 
+    /**
+     * Returns an overview message about the result of the find operation, including the
+     * number of items that match the search criteria.
+     */
     abstract String getResultOverviewMessage(int numberOfResults);
 }

--- a/src/main/java/seedu/address/logic/abstractcommand/FindCommand.java
+++ b/src/main/java/seedu/address/logic/abstractcommand/FindCommand.java
@@ -44,5 +44,5 @@ public abstract class FindCommand<T extends Item> extends ItemCommand<T> {
      * Returns an overview message about the result of the find operation, including the
      * number of items that match the search criteria.
      */
-    abstract String getResultOverviewMessage(int numberOfResults);
+    public abstract String getResultOverviewMessage(int numberOfResults);
 }

--- a/src/main/java/seedu/address/logic/abstractcommand/ItemCommand.java
+++ b/src/main/java/seedu/address/logic/abstractcommand/ItemCommand.java
@@ -1,5 +1,9 @@
 package seedu.address.logic.abstractcommand;
 
+import static java.util.Objects.requireNonNull;
+
+import java.util.function.Function;
+
 import seedu.address.logic.commands.Command;
 import seedu.address.model.Model;
 import seedu.address.model.item.Item;
@@ -7,6 +11,10 @@ import seedu.address.model.item.ItemManagerWithFilteredList;
 
 public abstract class ItemCommand<T extends Item> extends Command {
 
-    public abstract ItemManagerWithFilteredList<T> getManagerAndList(Model model);
+    protected final Function<Model, ItemManagerWithFilteredList<T>> managerAndListGetter;
 
+    public ItemCommand(Function<Model, ItemManagerWithFilteredList<T>> managerAndListGetter) {
+        requireNonNull(managerAndListGetter);
+        this.managerAndListGetter = managerAndListGetter;
+    }
 }

--- a/src/main/java/seedu/address/logic/abstractcommand/ItemCommand.java
+++ b/src/main/java/seedu/address/logic/abstractcommand/ItemCommand.java
@@ -1,0 +1,12 @@
+package seedu.address.logic.abstractcommand;
+
+import seedu.address.logic.commands.Command;
+import seedu.address.model.Model;
+import seedu.address.model.item.Item;
+import seedu.address.model.item.ItemManagerWithFilteredList;
+
+public abstract class ItemCommand<T extends Item> extends Command {
+
+    public abstract ItemManagerWithFilteredList<T> getManagerAndList(Model model);
+
+}

--- a/src/main/java/seedu/address/logic/abstractcommand/ItemCommand.java
+++ b/src/main/java/seedu/address/logic/abstractcommand/ItemCommand.java
@@ -9,10 +9,27 @@ import seedu.address.model.Model;
 import seedu.address.model.item.Item;
 import seedu.address.model.item.ItemManagerWithFilteredList;
 
+/**
+ * Abstract command class for operations that involve items in the model.
+ * <p>
+ * This class serves as a base for commands that operate on {@link Item} objects and need to access
+ * an {@link ItemManagerWithFilteredList} to manage the items in the model.
+ *
+ * @param <T> the type of {@code Item} that the command operates on, which must extend
+ *            {@link Item}.
+ */
 public abstract class ItemCommand<T extends Item> extends Command {
 
     protected final Function<Model, ItemManagerWithFilteredList<T>> managerAndListGetter;
 
+    /**
+     * Creates an {@code ItemCommand} with the specified function for retrieving the
+     * {@link ItemManagerWithFilteredList}.
+     *
+     * @param managerAndListGetter a function that retrieves the {@link ItemManagerWithFilteredList}
+     *                             for the current model.
+     * @throws NullPointerException if {@code managerAndListGetter} is {@code null}.
+     */
     public ItemCommand(Function<Model, ItemManagerWithFilteredList<T>> managerAndListGetter) {
         requireNonNull(managerAndListGetter);
         this.managerAndListGetter = managerAndListGetter;

--- a/src/main/java/seedu/address/logic/abstractcommand/ListCommand.java
+++ b/src/main/java/seedu/address/logic/abstractcommand/ListCommand.java
@@ -1,0 +1,20 @@
+package seedu.address.logic.abstractcommand;
+
+import static java.util.Objects.requireNonNull;
+
+import seedu.address.logic.commands.CommandResult;
+import seedu.address.model.Model;
+import seedu.address.model.item.Item;
+import seedu.address.model.item.ItemManagerWithFilteredList;
+
+public abstract class ListCommand<T extends Item> extends ItemCommand<T> {
+    @Override
+    public CommandResult execute(Model model) {
+        requireNonNull(model);
+        ItemManagerWithFilteredList<T> managerAndList = getManagerAndList(model);
+        managerAndList.showAllItems();
+        return new CommandResult(getSuccessMessage());
+    }
+
+    abstract String getSuccessMessage();
+}

--- a/src/main/java/seedu/address/logic/abstractcommand/ListCommand.java
+++ b/src/main/java/seedu/address/logic/abstractcommand/ListCommand.java
@@ -2,16 +2,22 @@ package seedu.address.logic.abstractcommand;
 
 import static java.util.Objects.requireNonNull;
 
+import java.util.function.Function;
+
 import seedu.address.logic.commands.CommandResult;
 import seedu.address.model.Model;
 import seedu.address.model.item.Item;
 import seedu.address.model.item.ItemManagerWithFilteredList;
 
 public abstract class ListCommand<T extends Item> extends ItemCommand<T> {
+    public ListCommand(Function<Model, ItemManagerWithFilteredList<T>> managerAndListGetter) {
+        super(managerAndListGetter);
+    }
+
     @Override
     public CommandResult execute(Model model) {
         requireNonNull(model);
-        ItemManagerWithFilteredList<T> managerAndList = getManagerAndList(model);
+        ItemManagerWithFilteredList<T> managerAndList = managerAndListGetter.apply(model);
         managerAndList.showAllItems();
         return new CommandResult(getSuccessMessage());
     }

--- a/src/main/java/seedu/address/logic/abstractcommand/ListCommand.java
+++ b/src/main/java/seedu/address/logic/abstractcommand/ListCommand.java
@@ -35,5 +35,5 @@ public abstract class ListCommand<T extends Item> extends ItemCommand<T> {
     /**
      * Returns a success message to be displayed when the command executes successfully.
      */
-    abstract String getSuccessMessage();
+    public abstract String getSuccessMessage();
 }

--- a/src/main/java/seedu/address/logic/abstractcommand/ListCommand.java
+++ b/src/main/java/seedu/address/logic/abstractcommand/ListCommand.java
@@ -9,7 +9,17 @@ import seedu.address.model.Model;
 import seedu.address.model.item.Item;
 import seedu.address.model.item.ItemManagerWithFilteredList;
 
+
+/**
+ * A command to list all {@code T} items in the model.
+ *
+ * @param <T> the type of {@code Item} being listed, which must extend {@link Item}.
+ */
 public abstract class ListCommand<T extends Item> extends ItemCommand<T> {
+
+    /**
+     * Creates a {@code ListCommand}.
+     */
     public ListCommand(Function<Model, ItemManagerWithFilteredList<T>> managerAndListGetter) {
         super(managerAndListGetter);
     }
@@ -22,5 +32,8 @@ public abstract class ListCommand<T extends Item> extends ItemCommand<T> {
         return new CommandResult(getSuccessMessage());
     }
 
+    /**
+     * Returns a success message to be displayed when the command executes successfully.
+     */
     abstract String getSuccessMessage();
 }

--- a/src/main/java/seedu/address/model/item/DuplicateChecker.java
+++ b/src/main/java/seedu/address/model/item/DuplicateChecker.java
@@ -1,0 +1,2 @@
+package seedu.address.model.item;public class DuplicateChecker {
+}

--- a/src/main/java/seedu/address/model/item/DuplicateChecker.java
+++ b/src/main/java/seedu/address/model/item/DuplicateChecker.java
@@ -1,5 +1,18 @@
 package seedu.address.model.item;
 
+/**
+ * An interface for checking if two items are duplicates of each other.
+ *
+ * @param <T> the type of item to be checked for duplicates. This type must extend {@link Item}.
+ */
 public interface DuplicateChecker<T extends Item> {
+
+    /**
+     * Checks if two given items are considered duplicates of each other.
+     *
+     * @param first the first item to compare.
+     * @param second the second item to compare.
+     * @return {@code true} if the items are duplicates, {@code false} otherwise.
+     */
     boolean check(T first, T second);
 }

--- a/src/main/java/seedu/address/model/item/DuplicateChecker.java
+++ b/src/main/java/seedu/address/model/item/DuplicateChecker.java
@@ -1,2 +1,5 @@
-package seedu.address.model.item;public class DuplicateChecker {
+package seedu.address.model.item;
+
+public interface DuplicateChecker<T extends Item> {
+    boolean check(T first, T second);
 }

--- a/src/main/java/seedu/address/model/item/Item.java
+++ b/src/main/java/seedu/address/model/item/Item.java
@@ -1,2 +1,4 @@
-package seedu.address.model.item;public class Item {
+package seedu.address.model.item;
+
+public interface Item {
 }

--- a/src/main/java/seedu/address/model/item/Item.java
+++ b/src/main/java/seedu/address/model/item/Item.java
@@ -1,0 +1,2 @@
+package seedu.address.model.item;public class Item {
+}

--- a/src/main/java/seedu/address/model/item/Item.java
+++ b/src/main/java/seedu/address/model/item/Item.java
@@ -1,4 +1,7 @@
 package seedu.address.model.item;
 
+/**
+ * Represents an item that is to be tracked in TutorConnect.
+ */
 public interface Item {
 }

--- a/src/main/java/seedu/address/model/item/ItemManager.java
+++ b/src/main/java/seedu/address/model/item/ItemManager.java
@@ -6,6 +6,11 @@ import java.util.List;
 
 import javafx.collections.ObservableList;
 
+/**
+ * Wraps all {@code T}-related data. Duplicates are not allowed.
+ *
+ * @param <T> the type of {@code Item} being managed, which extends {@link Item}.
+ */
 public abstract class ItemManager<T extends Item> {
 
     private final UniqueItemList<T> items;
@@ -16,10 +21,17 @@ public abstract class ItemManager<T extends Item> {
 
     //// list overwrite operations
 
+    /**
+     * Replaces the contents of the item list with {@code items}.
+     * {@code items} must not contain duplicate items.
+     */
     public void setItems(List<T> items) {
         this.items.setItems(items);
     }
 
+    /**
+     * Resets the existing data of this {@code ItemManager} with {@code newData}.
+     */
     public void resetData(ItemManager<T> newData) {
         requireNonNull(newData);
 
@@ -28,25 +40,46 @@ public abstract class ItemManager<T extends Item> {
 
     //// item-level operations
 
+    /**
+     * Returns true if an item with the same identity as {@code item} exists in the manager.
+     */
     public boolean hasItem(T item) {
         requireNonNull(item);
         return items.contains(item);
     }
 
+    /**
+     * Adds an item to the manager.
+     * The item must not already exist in the manager.
+     */
     public void addItem(T p) {
         items.add(p);
     }
 
+    /**
+     * Replaces the given item {@code target} in the list with {@code editedItem}.
+     * {@code target} must exist in the manager.
+     * The identity of {@code editedItem} must not be the same as another existing item in the
+     * manager.
+     */
     public void setItem(T target, T editedItem) {
         requireNonNull(editedItem);
 
         items.setItem(target, editedItem);
     }
 
+    /**
+     * Removes {@code key} from this {@code ItemManager}.
+     * {@code key} must exist in the manager.
+     */
     public void removeItem(T key) {
         items.remove(key);
     }
 
+    /**
+     * Returns an unmodifiable view of the item list.
+     * This list will not contain any duplicate items.
+     */
     public ObservableList<T> getItemList() {
         return items.asUnmodifiableObservableList();
     }

--- a/src/main/java/seedu/address/model/item/ItemManager.java
+++ b/src/main/java/seedu/address/model/item/ItemManager.java
@@ -1,0 +1,2 @@
+package seedu.address.model.item;public class ItemManager {
+}

--- a/src/main/java/seedu/address/model/item/ItemManager.java
+++ b/src/main/java/seedu/address/model/item/ItemManager.java
@@ -1,2 +1,72 @@
-package seedu.address.model.item;public class ItemManager {
+package seedu.address.model.item;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.List;
+
+import javafx.collections.ObservableList;
+
+public abstract class ItemManager<T extends Item> {
+
+    private final UniqueItemList<T> items;
+
+    public ItemManager(UniqueItemList<T> items) {
+        this.items = items;
+    }
+
+    //// list overwrite operations
+
+    public void setItems(List<T> items) {
+        this.items.setItems(items);
+    }
+
+    public void resetData(ItemManager<T> newData) {
+        requireNonNull(newData);
+
+        setItems(newData.getItemList());
+    }
+
+    //// item-level operations
+
+    public boolean hasItem(T item) {
+        requireNonNull(item);
+        return items.contains(item);
+    }
+
+    public void addItem(T p) {
+        items.add(p);
+    }
+
+    public void setItem(T target, T editedItem) {
+        requireNonNull(editedItem);
+
+        items.setItem(target, editedItem);
+    }
+
+    public void removeItem(T key) {
+        items.remove(key);
+    }
+
+    public ObservableList<T> getItemList() {
+        return items.asUnmodifiableObservableList();
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof ItemManager<?> otherAddressBook)) {
+            return false;
+        }
+
+        return items.equals(otherAddressBook.items);
+    }
+
+    @Override
+    public int hashCode() {
+        return items.hashCode();
+    }
 }

--- a/src/main/java/seedu/address/model/item/ItemManagerWithFilteredList.java
+++ b/src/main/java/seedu/address/model/item/ItemManagerWithFilteredList.java
@@ -1,0 +1,2 @@
+package seedu.address.model.item;public class ItemManagerWithFilteredList {
+}

--- a/src/main/java/seedu/address/model/item/ItemManagerWithFilteredList.java
+++ b/src/main/java/seedu/address/model/item/ItemManagerWithFilteredList.java
@@ -1,2 +1,76 @@
-package seedu.address.model.item;public class ItemManagerWithFilteredList {
+package seedu.address.model.item;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
+
+import java.util.function.Predicate;
+
+import javafx.collections.ObservableList;
+import javafx.collections.transformation.FilteredList;
+
+public abstract class ItemManagerWithFilteredList<T extends Item> {
+    private final Predicate<T> PREDICATE_SHOW_ALL = unused -> true;
+    private final ItemManager<T> itemManager;
+    private final FilteredList<T> filteredItems;
+
+    public ItemManagerWithFilteredList(ItemManager<T> itemManager) {
+        requireAllNonNull(itemManager);
+        this.itemManager = itemManager;
+        filteredItems = new FilteredList<>(this.itemManager.getItemList());
+    }
+
+    //=========== ItemManager ================================================================================
+
+    public void setItemManager(ItemManager<T> itemManager) {
+        this.itemManager.resetData(itemManager);
+    }
+
+    public ItemManager<T> getAddressBook() {
+        return itemManager;
+    }
+
+    public boolean hasItem(T item) {
+        requireNonNull(item);
+        return itemManager.hasItem(item);
+    }
+
+    public void deleteItem(T target) {
+        itemManager.removeItem(target);
+    }
+
+    public void addItem(T item) {
+        itemManager.addItem(item);
+        updateFilteredItemsList(PREDICATE_SHOW_ALL);
+    }
+
+    public void setItem(T target, T editedItem) {
+        requireAllNonNull(target, editedItem);
+
+        itemManager.setItem(target, editedItem);
+    }
+
+    //=========== Filtered Item List Accessors =============================================================
+
+    public ObservableList<T> getFilteredItemsList() {
+        return filteredItems;
+    }
+
+    public void updateFilteredItemsList(Predicate<T> predicate) {
+        requireNonNull(predicate);
+        filteredItems.setPredicate(predicate);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        if (!(other instanceof ItemManagerWithFilteredList<?> otherManagerAndList)) {
+            return false;
+        }
+
+        return itemManager.equals(otherManagerAndList.itemManager)
+                && filteredItems.equals(otherManagerAndList.filteredItems);
+    }
 }

--- a/src/main/java/seedu/address/model/item/ItemManagerWithFilteredList.java
+++ b/src/main/java/seedu/address/model/item/ItemManagerWithFilteredList.java
@@ -40,7 +40,7 @@ public abstract class ItemManagerWithFilteredList<T extends Item> {
 
     public void addItem(T item) {
         itemManager.addItem(item);
-        updateFilteredItemsList(PREDICATE_SHOW_ALL);
+        showAllItems();
     }
 
     public void setItem(T target, T editedItem) {
@@ -58,6 +58,10 @@ public abstract class ItemManagerWithFilteredList<T extends Item> {
     public void updateFilteredItemsList(Predicate<T> predicate) {
         requireNonNull(predicate);
         filteredItems.setPredicate(predicate);
+    }
+
+    public void showAllItems() {
+        filteredItems.setPredicate(PREDICATE_SHOW_ALL);
     }
 
     @Override

--- a/src/main/java/seedu/address/model/item/ItemManagerWithFilteredList.java
+++ b/src/main/java/seedu/address/model/item/ItemManagerWithFilteredList.java
@@ -8,60 +8,104 @@ import java.util.function.Predicate;
 import javafx.collections.ObservableList;
 import javafx.collections.transformation.FilteredList;
 
+/**
+ * Manages a list of {@code Item} objects and provides a filtered list for display purposes.
+ * Duplicates are not allowed in the underlying list.
+ *
+ * @param <T> the type of {@code Item} being managed, which must extend {@link Item}.
+ */
 public abstract class ItemManagerWithFilteredList<T extends Item> {
-    private final Predicate<T> PREDICATE_SHOW_ALL = unused -> true;
+    private final Predicate<T> predicateShowAll = unused -> true;
     private final ItemManager<T> itemManager;
     private final FilteredList<T> filteredItems;
 
+    /**
+     * Constructs an {@code ItemManagerWithFilteredList} with the specified {@code ItemManager}.
+     * Initializes the filtered item list to the list of items from the provided
+     * {@code itemManager}.
+     *
+     * @throws NullPointerException if {@code itemManager} is {@code null}.
+     */
     public ItemManagerWithFilteredList(ItemManager<T> itemManager) {
         requireAllNonNull(itemManager);
         this.itemManager = itemManager;
         filteredItems = new FilteredList<>(this.itemManager.getItemList());
     }
 
-    //=========== ItemManager ================================================================================
+    //=========== ItemManager ======================================================================
 
+    /**
+     * Replaces the {@code ItemManager} data with the data in {@code itemManager}.
+     */
     public void setItemManager(ItemManager<T> itemManager) {
         this.itemManager.resetData(itemManager);
     }
 
-    public ItemManager<T> getAddressBook() {
+    /**
+     * Returns the {@code ItemManager}
+     */
+    public ItemManager<T> getItemManager() {
         return itemManager;
     }
 
+    /**
+     * Returns true if an item with the same identity as {@code item} exists in the manager.
+     */
     public boolean hasItem(T item) {
         requireNonNull(item);
         return itemManager.hasItem(item);
     }
 
+    /**
+     * Deletes the given item. The item must exist in the manager.
+     */
     public void deleteItem(T target) {
         itemManager.removeItem(target);
     }
 
+    /**
+     * Adds the given item. {@code item} must not already exist in the manager.
+     */
     public void addItem(T item) {
         itemManager.addItem(item);
         showAllItems();
     }
 
+    /**
+     * Replaces the given item {@code target} with {@code editedItem}. {@code target} must exist in
+     * the manager. The identity of {@code editedItem} must not be the same as another existing item
+     * in the manager.
+     */
     public void setItem(T target, T editedItem) {
         requireAllNonNull(target, editedItem);
 
         itemManager.setItem(target, editedItem);
     }
 
-    //=========== Filtered Item List Accessors =============================================================
+    //=========== Filtered Item List Accessors =====================================================
 
+    /**
+     * Returns an unmodifiable view of the filtered person list
+     */
     public ObservableList<T> getFilteredItemsList() {
         return filteredItems;
     }
 
+    /**
+     * Updates the filter of the filtered item list to filter by the given {@code predicate}.
+     *
+     * @throws NullPointerException if {@code predicate} is null.
+     */
     public void updateFilteredItemsList(Predicate<T> predicate) {
         requireNonNull(predicate);
         filteredItems.setPredicate(predicate);
     }
 
+    /**
+     * Resets the filter of the filtered item list to show all items.
+     */
     public void showAllItems() {
-        filteredItems.setPredicate(PREDICATE_SHOW_ALL);
+        filteredItems.setPredicate(predicateShowAll);
     }
 
     @Override

--- a/src/main/java/seedu/address/model/item/UniqueItemList.java
+++ b/src/main/java/seedu/address/model/item/UniqueItemList.java
@@ -1,2 +1,123 @@
-package seedu.address.model.item;public class UniqueItemList {
+package seedu.address.model.item;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
+
+import java.util.Iterator;
+import java.util.List;
+
+import javafx.collections.FXCollections;
+import javafx.collections.ObservableList;
+
+public abstract class UniqueItemList<T extends Item> implements Iterable<T> {
+
+    private final ObservableList<T> internalList = FXCollections.observableArrayList();
+    private final ObservableList<T> internalUnmodifiableList =
+            FXCollections.unmodifiableObservableList(internalList);
+    private final DuplicateChecker<T> duplicateChecker;
+
+    public UniqueItemList(DuplicateChecker<T> duplicateChecker) {
+        this.duplicateChecker = duplicateChecker;
+    }
+
+    public boolean contains(T toCheck) {
+        requireNonNull(toCheck);
+        return internalList.stream().anyMatch(elem -> duplicateChecker.check(elem, toCheck));
+    }
+
+    public void add(T toAdd) {
+        requireNonNull(toAdd);
+        if (contains(toAdd)) {
+            throwDuplicateException();
+            return;
+        }
+        internalList.add(toAdd);
+    }
+
+    public void setItem(T target, T editedItem) {
+        requireAllNonNull(target, editedItem);
+
+        int index = internalList.indexOf(target);
+        if (index == -1) {
+            throwNotFoundException();
+            return;
+        }
+
+        if (!duplicateChecker.check(target, editedItem) && contains(editedItem)) {
+            throwDuplicateException();
+            return;
+        }
+
+        internalList.set(index, editedItem);
+    }
+
+    public void remove(T toRemove) {
+        requireNonNull(toRemove);
+        if (!internalList.remove(toRemove)) {
+            throwNotFoundException();
+        }
+    }
+
+    public <U extends T> void setItems(UniqueItemList<U> replacement) {
+        requireNonNull(replacement);
+        internalList.setAll(replacement.internalList);
+    }
+
+    public void setItems(List<T> items) {
+        requireAllNonNull(items);
+        if (!itemsAreUnique(items)) {
+            throwDuplicateException();
+            return;
+        }
+
+        internalList.setAll(items);
+    }
+
+    public ObservableList<T> asUnmodifiableObservableList() {
+        return internalUnmodifiableList;
+    }
+
+    @Override
+    public Iterator<T> iterator() {
+        return internalList.iterator();
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof UniqueItemList<?> otherUniqueItemList)) {
+            return false;
+        }
+
+        return internalList.equals(otherUniqueItemList.internalList);
+    }
+
+    @Override
+    public int hashCode() {
+        return internalList.hashCode();
+    }
+
+    @Override
+    public String toString() {
+        return internalList.toString();
+    }
+
+    private boolean itemsAreUnique(List<T> items) {
+        for (int i = 0; i < items.size() - 1; i++) {
+            for (int j = i + 1; j < items.size(); j++) {
+                if (duplicateChecker.check(items.get(i), items.get(j))) {
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
+
+    abstract void throwDuplicateException();
+    abstract void throwNotFoundException();
 }
+

--- a/src/main/java/seedu/address/model/item/UniqueItemList.java
+++ b/src/main/java/seedu/address/model/item/UniqueItemList.java
@@ -9,6 +9,12 @@ import java.util.List;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 
+/**
+ * A list of items that enforces uniqueness between its elements and does not allow nulls.
+ * Supports a minimal set of list operations.
+ *
+ * @param <T> the type of item to be stored in the list, which extends {@link Item}.
+ */
 public abstract class UniqueItemList<T extends Item> implements Iterable<T> {
 
     private final ObservableList<T> internalList = FXCollections.observableArrayList();
@@ -16,15 +22,27 @@ public abstract class UniqueItemList<T extends Item> implements Iterable<T> {
             FXCollections.unmodifiableObservableList(internalList);
     private final DuplicateChecker<T> duplicateChecker;
 
+    /**
+     * Constructs a {@code UniqueItemList} with the given {@code duplicateChecker}.
+     *
+     * @param duplicateChecker the {@code DuplicateChecker} used to check for duplicates.
+     */
     public UniqueItemList(DuplicateChecker<T> duplicateChecker) {
         this.duplicateChecker = duplicateChecker;
     }
 
+    /**
+     * Returns true if the list contains an equivalent item as the given argument.
+     */
     public boolean contains(T toCheck) {
         requireNonNull(toCheck);
         return internalList.stream().anyMatch(elem -> duplicateChecker.check(elem, toCheck));
     }
 
+    /**
+     * Adds an item to the list.
+     * The item must not already exist in the list.
+     */
     public void add(T toAdd) {
         requireNonNull(toAdd);
         if (contains(toAdd)) {
@@ -34,6 +52,11 @@ public abstract class UniqueItemList<T extends Item> implements Iterable<T> {
         internalList.add(toAdd);
     }
 
+    /**
+     * Replaces the item {@code target} in the list with {@code editedItem}.
+     * {@code target} must exist in the list.
+     * {@code editedPerson} must not be the same as another existing item in the list.
+     */
     public void setItem(T target, T editedItem) {
         requireAllNonNull(target, editedItem);
 
@@ -51,6 +74,10 @@ public abstract class UniqueItemList<T extends Item> implements Iterable<T> {
         internalList.set(index, editedItem);
     }
 
+    /**
+     * Removes the equivalent item from the list.
+     * The item must exist in the list.
+     */
     public void remove(T toRemove) {
         requireNonNull(toRemove);
         if (!internalList.remove(toRemove)) {
@@ -63,6 +90,10 @@ public abstract class UniqueItemList<T extends Item> implements Iterable<T> {
         internalList.setAll(replacement.internalList);
     }
 
+    /**
+     * Replaces the contents of this list with {@code items}.
+     * {@code items} must not contain duplicate persons.
+     */
     public void setItems(List<T> items) {
         requireAllNonNull(items);
         if (!itemsAreUnique(items)) {
@@ -73,6 +104,9 @@ public abstract class UniqueItemList<T extends Item> implements Iterable<T> {
         internalList.setAll(items);
     }
 
+    /**
+     * Returns the backing list as an unmodifiable {@code ObservableList}.
+     */
     public ObservableList<T> asUnmodifiableObservableList() {
         return internalUnmodifiableList;
     }
@@ -106,6 +140,9 @@ public abstract class UniqueItemList<T extends Item> implements Iterable<T> {
         return internalList.toString();
     }
 
+    /**
+     * Returns true if {@code items} contains only unique persons.
+     */
     private boolean itemsAreUnique(List<T> items) {
         for (int i = 0; i < items.size() - 1; i++) {
             for (int j = i + 1; j < items.size(); j++) {
@@ -117,7 +154,14 @@ public abstract class UniqueItemList<T extends Item> implements Iterable<T> {
         return true;
     }
 
+    /**
+     * Throws an exception when attempting to add a duplicate item.
+     */
     abstract void throwDuplicateException();
+
+    /**
+     * Throws an exception when attempting to modify an item that does not exist in the list.
+     */
     abstract void throwNotFoundException();
 }
 

--- a/src/main/java/seedu/address/model/item/UniqueItemList.java
+++ b/src/main/java/seedu/address/model/item/UniqueItemList.java
@@ -1,0 +1,2 @@
+package seedu.address.model.item;public class UniqueItemList {
+}

--- a/src/main/java/seedu/address/model/item/UniqueItemList.java
+++ b/src/main/java/seedu/address/model/item/UniqueItemList.java
@@ -157,11 +157,11 @@ public abstract class UniqueItemList<T extends Item> implements Iterable<T> {
     /**
      * Throws an exception when attempting to add a duplicate item.
      */
-    abstract void throwDuplicateException();
+    public abstract void throwDuplicateException();
 
     /**
      * Throws an exception when attempting to modify an item that does not exist in the list.
      */
-    abstract void throwNotFoundException();
+    public abstract void throwNotFoundException();
 }
 


### PR DESCRIPTION
Since `Contact`, `Todo`, and `Event` share many common behaviors, I propose the following refactor:

1. Abstract classes for item management
   Since `Contact`, `Todo`, and `Event` can be stored in the model in the same way, we can create abstract classes to handle that. For each new item type `X`, we will:
   - Create the class `X` that implements an `Item` interface.
   - Create a concrete class `XDuplicateChecker` that extends `DuplicateChecker<X>`.
   - Create a concrete class `UniqueXList` that extends `UniqueItemList<X>`. This class functions similarly to the current `UniquePersonList`.
   - Create a concrete class `XManager` that extends `ItemManager<X>`. This class functions similarly to the current `AddressBook` class.
   - Create a concrete class `XManagerWithFilteredList` that extends `ItemManagerWithFilteredList<X>`. This will wrap around `XManager` and a `FilteredList` to manage displaying items.
   - The `Model` class, which currently manages `UserPrefs`, `ReadOnlyAddressBook`, and `FilteredList`, will delegate the latter two responsibilities to the `ItemManagerWithFilteredList<X>` classes.

2. Abstract command classes for common commands
   Since `Contact`, `Todo`, and `Event` share many common commands (e.g., `add`, `delete`, `edit` actions like `tag`, `untag`, `mark as done`), they can also be refactored into abstract command classes. The abstract classes will handle the core logic for implementing concrete commands. For new commands, we only need to specify the `XManagerWithFilteredList` the command works with and implement a few minor details. The bulk of the work will shift to parsing, though I suspect it could also be refactored in the future. However, I don't have an immediate solution for that at the moment.

Resolves #68 

