### PR TITLE
[#62] Add `find` command

### DIFF
--- a/src/main/java/seedu/address/logic/Messages.java
+++ b/src/main/java/seedu/address/logic/Messages.java
@@ -18,6 +18,7 @@ public class Messages {
     public static final String MESSAGE_PERSONS_LISTED_OVERVIEW = "%1$d persons listed!";
     public static final String MESSAGE_DUPLICATE_FIELDS =
                 "Multiple values specified for the following single-valued field(s): ";
+    public static final String MESSAGE_DISPLAY_SPECIFIC_PERSON_INFO = "Displaying full information of student: %s!";
 
     /**
      * Returns an error message indicating the duplicate prefixes.

--- a/src/main/java/seedu/address/logic/commands/InfoCommand.java
+++ b/src/main/java/seedu/address/logic/commands/InfoCommand.java
@@ -1,0 +1,74 @@
+package seedu.address.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.Messages.MESSAGE_DISPLAY_SPECIFIC_PERSON_INFO;
+
+import java.util.List;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.commons.util.ToStringBuilder;
+import seedu.address.logic.Messages;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.person.Person;
+
+/**
+ * Finds and lists all persons in address book whose name contains any of the argument keywords.
+ * Keyword matching is case insensitive.
+ */
+public class InfoCommand extends Command {
+
+    public static final String COMMAND_WORD = "info";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Displays the complete information belonging to the "
+            + "person identified by the index number used in the displayed person list.\n"
+            + "Parameters: INDEX (must be a positive integer)\n"
+            + "Example: " + COMMAND_WORD + " 2";
+
+    private final Index targetIndex;
+
+    public InfoCommand(Index targetIndex) {
+        this.targetIndex = targetIndex;
+    }
+
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+        List<Person> lastShownList = model.getFilteredPersonList();
+
+        if (targetIndex.getZeroBased() >= lastShownList.size()) {
+            throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+        }
+
+        Person personToDisplay = lastShownList.get(targetIndex.getZeroBased());
+
+        model.updateFilteredPersonList(person -> person.equals(personToDisplay));
+
+        return new CommandResult(
+                String.format(MESSAGE_DISPLAY_SPECIFIC_PERSON_INFO, personToDisplay.getName()));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof InfoCommand)) {
+            return false;
+        }
+
+        InfoCommand otherInfoCommand = (InfoCommand) other;
+        return targetIndex.equals(otherInfoCommand.targetIndex);
+    }
+
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this)
+                .add("targetIndex", targetIndex)
+                .toString();
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -16,6 +16,7 @@ import seedu.address.logic.commands.EditCommand;
 import seedu.address.logic.commands.ExitCommand;
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.HelpCommand;
+import seedu.address.logic.commands.InfoCommand;
 import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 
@@ -70,6 +71,9 @@ public class AddressBookParser {
 
         case ListCommand.COMMAND_WORD:
             return new ListCommand();
+
+        case InfoCommand.COMMAND_WORD:
+            return new InfoCommandParser().parse(arguments);
 
         case ExitCommand.COMMAND_WORD:
             return new ExitCommand();

--- a/src/main/java/seedu/address/logic/parser/InfoCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/InfoCommandParser.java
@@ -1,0 +1,28 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.InfoCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+
+/**
+ * Parses input arguments and creates a new InfoCommand object
+ */
+public class InfoCommandParser implements Parser<InfoCommand> {
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the InfoCommand
+     * and returns an InfoCommand object for execution.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public InfoCommand parse(String args) throws ParseException {
+        try {
+            Index index = ParserUtil.parseIndex(args);
+            return new InfoCommand(index);
+        } catch (ParseException pe) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, InfoCommand.MESSAGE_USAGE), pe);
+        }
+    }
+}

--- a/src/test/java/seedu/address/logic/commands/InfoCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/InfoCommandTest.java
@@ -1,0 +1,96 @@
+package seedu.address.logic.commands;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.logic.Messages.MESSAGE_DISPLAY_SPECIFIC_PERSON_INFO;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.logic.commands.CommandTestUtil.showPersonAtIndex;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
+import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
+import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.Messages;
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+import seedu.address.model.person.Person;
+
+/**
+ * Contains integration tests (interaction with the Model) for {@code InfoCommand}.
+ */
+public class InfoCommandTest {
+    private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+    private Model expectedModel = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+
+    @Test
+    public void execute_validIndexUnfilteredList_success() {
+        Person personToShow = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
+        InfoCommand infoCommand = new InfoCommand(INDEX_FIRST_PERSON);
+
+        String expectedMessage = String.format(MESSAGE_DISPLAY_SPECIFIC_PERSON_INFO, personToShow.getName());
+
+        expectedModel.updateFilteredPersonList(person -> person.equals(personToShow));
+        assertCommandSuccess(infoCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_invalidIndexUnfilteredList_throwsCommandException() {
+        Index outOfBoundIndex = Index.fromOneBased(model.getFilteredPersonList().size() + 1);
+        InfoCommand infoCommand = new InfoCommand(outOfBoundIndex);
+        assertCommandFailure(infoCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+    }
+
+    @Test
+    public void execute_validIndexFilteredList_success() {
+        showPersonAtIndex(model, INDEX_FIRST_PERSON);
+        showPersonAtIndex(expectedModel, INDEX_FIRST_PERSON);
+        Person personToShow = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
+        InfoCommand infoCommand = new InfoCommand(INDEX_FIRST_PERSON);
+        String expectedMessage = String.format(MESSAGE_DISPLAY_SPECIFIC_PERSON_INFO, personToShow.getName());
+        expectedModel.updateFilteredPersonList(person -> person.equals(personToShow));
+        assertCommandSuccess(infoCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_invalidIndexFilteredList_throwsCommandException() {
+        showPersonAtIndex(model, INDEX_FIRST_PERSON);
+        Index outOfBoundIndex = INDEX_SECOND_PERSON;
+        assertTrue(outOfBoundIndex.getZeroBased() < model.getAddressBook().getPersonList().size());
+        InfoCommand infoCommand = new InfoCommand(outOfBoundIndex);
+        assertCommandFailure(infoCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+    }
+
+    @Test
+    public void equals() {
+        InfoCommand showFirstCommand = new InfoCommand(INDEX_FIRST_PERSON);
+        InfoCommand showSecondCommand = new InfoCommand(INDEX_SECOND_PERSON);
+
+        // same object -> returns true
+        assertTrue(showFirstCommand.equals(showFirstCommand));
+
+        // same values -> returns true
+        InfoCommand showFirstCommandCopy = new InfoCommand(INDEX_FIRST_PERSON);
+        assertTrue(showFirstCommand.equals(showFirstCommandCopy));
+
+        // different types -> returns false
+        assertFalse(showFirstCommand.equals(1));
+
+        // null -> returns false
+        assertFalse(showFirstCommand.equals(null));
+
+        // different person -> returns false
+        assertFalse(showFirstCommand.equals(showSecondCommand));
+    }
+
+    @Test
+    public void toStringMethod() {
+        InfoCommand infoCommand = new InfoCommand(INDEX_FIRST_PERSON);
+        String expected = InfoCommand.class.getCanonicalName() + "{targetIndex=" + INDEX_FIRST_PERSON + "}";
+        assertEquals(expected, infoCommand.toString());
+    }
+}


### PR DESCRIPTION
Fixes #62 
Using the sample database,
`info 2`
<img width="852" alt="Screenshot 2025-03-12 at 16 52 24" src="https://github.com/user-attachments/assets/13380b0e-e377-408a-abbf-f96dee14224c" />

Resolves #63 by doing nothing.
`list`
<img width="852" alt="Screenshot 2025-03-12 at 16 51 06" src="https://github.com/user-attachments/assets/ae680ee7-a2b3-47c3-8db5-795e5b79f96a" />

* Display information works using index of contacts in a filtered/unfiltered list.
* Unit tests boilerplate implemented based on `FindCommandTest` and `DeleteCommandTest`. However since `PersonTest` is not fixed, I cannot ensure that the unit tests work or is comprehensive. 
