### PR TITLE
[#77] Add command to add a todo

### DIFF
--- a/src/main/java/seedu/address/logic/Logic.java
+++ b/src/main/java/seedu/address/logic/Logic.java
@@ -9,6 +9,7 @@ import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.ReadOnlyAddressBook;
 import seedu.address.model.person.Person;
+import seedu.address.model.todo.Todo;
 
 /**
  * API of the Logic component
@@ -32,6 +33,9 @@ public interface Logic {
 
     /** Returns an unmodifiable view of the filtered list of persons */
     ObservableList<Person> getFilteredPersonList();
+
+    /** Returns an unmodifiable view of the filtered list of todos */
+    ObservableList<Todo> getFilteredTodoList();
 
     /**
      * Returns the user prefs' address book file path.

--- a/src/main/java/seedu/address/logic/LogicManager.java
+++ b/src/main/java/seedu/address/logic/LogicManager.java
@@ -16,6 +16,7 @@ import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.Model;
 import seedu.address.model.ReadOnlyAddressBook;
 import seedu.address.model.person.Person;
+import seedu.address.model.todo.Todo;
 import seedu.address.storage.Storage;
 
 /**
@@ -69,6 +70,11 @@ public class LogicManager implements Logic {
     @Override
     public ObservableList<Person> getFilteredPersonList() {
         return model.getFilteredPersonList();
+    }
+
+    @Override
+    public ObservableList<Todo> getFilteredTodoList() {
+        return model.getTodoManagerAndList().getFilteredItemsList();
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/Messages.java
+++ b/src/main/java/seedu/address/logic/Messages.java
@@ -6,6 +6,7 @@ import java.util.stream.Stream;
 
 import seedu.address.logic.parser.Prefix;
 import seedu.address.model.person.Person;
+import seedu.address.model.todo.Todo;
 
 /**
  * Container for user visible messages.
@@ -54,4 +55,12 @@ public class Messages {
         return builder.toString();
     }
 
+    /**
+     * Formats the {@code todo} for display to the user.
+     */
+    public static String format(Todo todo) {
+        return todo.getName()
+                + "; Deadline: " + todo.getDeadline()
+                + "; Location: " + todo.getLocation();
+    }
 }

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -3,8 +3,8 @@ package seedu.address.logic.commands;
 import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_COURSE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_ID;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_GROUP;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_ID;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
@@ -39,7 +39,8 @@ public class EditCommand extends Command {
 
     public static final String COMMAND_WORD = "edit";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Edits the details of the person identified "
+    public static final String MESSAGE_USAGE = COMMAND_WORD
+            + ": Edits the details of the person identified "
             + "by the index number used in the displayed person list. "
             + "Existing values will be overwritten by the input values.\n"
             + "Parameters: INDEX (must be a positive integer) "
@@ -56,13 +57,14 @@ public class EditCommand extends Command {
 
     public static final String MESSAGE_EDIT_PERSON_SUCCESS = "Edited Person: %1$s";
     public static final String MESSAGE_NOT_EDITED = "At least one field to edit must be provided.";
-    public static final String MESSAGE_DUPLICATE_PERSON = "This person already exists in the address book.";
+    public static final String MESSAGE_DUPLICATE_PERSON =
+            "This person already exists in the address book.";
 
     private final Index index;
     private final EditPersonDescriptor editPersonDescriptor;
 
     /**
-     * @param index of the person in the filtered person list to edit
+     * @param index                of the person in the filtered person list to edit
      * @param editPersonDescriptor details to edit the person with
      */
     public EditCommand(Index index, EditPersonDescriptor editPersonDescriptor) {
@@ -91,14 +93,16 @@ public class EditCommand extends Command {
 
         model.setPerson(personToEdit, editedPerson);
         model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
-        return new CommandResult(String.format(MESSAGE_EDIT_PERSON_SUCCESS, Messages.format(editedPerson)));
+        return new CommandResult(String.format(MESSAGE_EDIT_PERSON_SUCCESS,
+                Messages.format(editedPerson)));
     }
 
     /**
-     * Creates and returns a {@code Person} with the details of {@code personToEdit}
-     * edited with {@code editPersonDescriptor}.
+     * Creates and returns a {@code Person} with the details of {@code personToEdit} edited with
+     * {@code editPersonDescriptor}.
      */
-    private static Person createEditedPerson(Person personToEdit, EditPersonDescriptor editPersonDescriptor) {
+    private static Person createEditedPerson(Person personToEdit,
+                                             EditPersonDescriptor editPersonDescriptor) {
         assert personToEdit != null;
 
         Id updatedId = editPersonDescriptor.getId().orElse(personToEdit.getId());
@@ -110,7 +114,7 @@ public class EditCommand extends Command {
         Set<Tag> updatedTags = editPersonDescriptor.getTags().orElse(personToEdit.getTags());
 
         return new Person(updatedId, updatedName, updatedPhone, updatedEmail, updatedCourse,
-            updatedGroup, updatedTags);
+                updatedGroup, updatedTags);
     }
 
     @Override
@@ -126,15 +130,15 @@ public class EditCommand extends Command {
 
         EditCommand otherEditCommand = (EditCommand) other;
         return index.equals(otherEditCommand.index)
-               && editPersonDescriptor.equals(otherEditCommand.editPersonDescriptor);
+                && editPersonDescriptor.equals(otherEditCommand.editPersonDescriptor);
     }
 
     @Override
     public String toString() {
         return new ToStringBuilder(this)
-            .add("index", index)
-            .add("editPersonDescriptor", editPersonDescriptor)
-            .toString();
+                .add("index", index)
+                .add("editPersonDescriptor", editPersonDescriptor)
+                .toString();
     }
 
     /**
@@ -154,8 +158,7 @@ public class EditCommand extends Command {
         }
 
         /**
-         * Copy constructor.
-         * A defensive copy of {@code tags} is used internally.
+         * Copy constructor. A defensive copy of {@code tags} is used internally.
          */
         public EditPersonDescriptor(EditPersonDescriptor toCopy) {
             setId(toCopy.id);
@@ -223,17 +226,17 @@ public class EditCommand extends Command {
         }
 
         /**
-         * Returns an unmodifiable tag set, which throws {@code UnsupportedOperationException}
-         * if modification is attempted.
-         * Returns {@code Optional#empty()} if {@code tags} is null.
+         * Returns an unmodifiable tag set, which throws {@code UnsupportedOperationException} if
+         * modification is attempted. Returns {@code Optional#empty()} if {@code tags} is null.
          */
         public Optional<Set<Tag>> getTags() {
-            return (tags != null) ? Optional.of(Collections.unmodifiableSet(tags)) : Optional.empty();
+            return (tags != null) ? Optional.of(Collections.unmodifiableSet(tags))
+                    : Optional.empty();
         }
 
         /**
-         * Sets {@code tags} to this object's {@code tags}.
-         * A defensive copy of {@code tags} is used internally.
+         * Sets {@code tags} to this object's {@code tags}. A defensive copy of {@code tags} is used
+         * internally.
          */
         public void setTags(Set<Tag> tags) {
             this.tags = (tags != null) ? new HashSet<>(tags) : null;
@@ -252,25 +255,25 @@ public class EditCommand extends Command {
 
             EditPersonDescriptor otherEditPersonDescriptor = (EditPersonDescriptor) other;
             return Objects.equals(id, otherEditPersonDescriptor.id)
-                   && Objects.equals(name, otherEditPersonDescriptor.name)
-                   && Objects.equals(phone, otherEditPersonDescriptor.phone)
-                   && Objects.equals(email, otherEditPersonDescriptor.email)
-                   && Objects.equals(course, otherEditPersonDescriptor.course)
-                   && Objects.equals(group, otherEditPersonDescriptor.group)
-                   && Objects.equals(tags, otherEditPersonDescriptor.tags);
+                    && Objects.equals(name, otherEditPersonDescriptor.name)
+                    && Objects.equals(phone, otherEditPersonDescriptor.phone)
+                    && Objects.equals(email, otherEditPersonDescriptor.email)
+                    && Objects.equals(course, otherEditPersonDescriptor.course)
+                    && Objects.equals(group, otherEditPersonDescriptor.group)
+                    && Objects.equals(tags, otherEditPersonDescriptor.tags);
         }
 
         @Override
         public String toString() {
             return new ToStringBuilder(this)
-                .add("id", id)
-                .add("name", name)
-                .add("phone", phone)
-                .add("email", email)
-                .add("course", course)
-                .add("group", group)
-                .add("tags", tags)
-                .toString();
+                    .add("id", id)
+                    .add("name", name)
+                    .add("phone", phone)
+                    .add("email", email)
+                    .add("course", course)
+                    .add("group", group)
+                    .add("tags", tags)
+                    .toString();
         }
 
     }

--- a/src/main/java/seedu/address/logic/commands/todo/AddTodoCommand.java
+++ b/src/main/java/seedu/address/logic/commands/todo/AddTodoCommand.java
@@ -1,0 +1,50 @@
+package seedu.address.logic.commands.todo;
+
+import static seedu.address.logic.parser.CliSyntax.TODO_COMMAND_WORD;
+import static seedu.address.logic.parser.todo.TodoCliSyntax.PREFIX_TODO_DEADLINE;
+import static seedu.address.logic.parser.todo.TodoCliSyntax.PREFIX_TODO_LOCATION;
+import static seedu.address.logic.parser.todo.TodoCliSyntax.PREFIX_TODO_NAME;
+
+import seedu.address.logic.Messages;
+import seedu.address.logic.abstractcommand.AddCommand;
+import seedu.address.model.Model;
+import seedu.address.model.todo.Todo;
+
+/**
+ * Adds a todo.
+ */
+public class AddTodoCommand extends AddCommand<Todo> {
+
+    public static final String COMMAND_WORD = "add";
+
+    public static final String MESSAGE_USAGE = TODO_COMMAND_WORD + " " + COMMAND_WORD
+            + ": Adds a todo to the app. "
+            + "Parameters: "
+            + PREFIX_TODO_NAME + "NAME "
+            + PREFIX_TODO_DEADLINE + "PREFIX_TODO_DEADLINE "
+            + PREFIX_TODO_LOCATION + "LOCATION\n"
+            + "Example: " + TODO_COMMAND_WORD + " " + COMMAND_WORD + " "
+            + PREFIX_TODO_NAME + "Grading students' projects"
+            + PREFIX_TODO_DEADLINE + "25-05-23 17:00 "
+            + PREFIX_TODO_LOCATION + "NUS Science ";
+
+    public static final String MESSAGE_SUCCESS = "New todo added: %1$s";
+    public static final String MESSAGE_DUPLICATE_TODO = "This todo already exists";
+
+    /**
+     * Creates an AddTodoCommand to add the specified {@code todo}.
+     */
+    public AddTodoCommand(Todo todo) {
+        super(todo, Model::getTodoManagerAndList);
+    }
+
+    @Override
+    public String getDuplicateItemMessage() {
+        return MESSAGE_DUPLICATE_TODO;
+    }
+
+    @Override
+    public String getSuccessMessage(Todo todo) {
+        return String.format(MESSAGE_SUCCESS, Messages.format(todo));
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -2,6 +2,7 @@ package seedu.address.logic.parser;
 
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.Messages.MESSAGE_UNKNOWN_COMMAND;
+import static seedu.address.logic.parser.CliSyntax.TODO_COMMAND_WORD;
 
 import java.util.logging.Logger;
 import java.util.regex.Matcher;
@@ -19,6 +20,7 @@ import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.InfoCommand;
 import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.logic.parser.todo.TodoParser;
 
 /**
  * Parses user input.
@@ -80,6 +82,9 @@ public class AddressBookParser {
 
         case HelpCommand.COMMAND_WORD:
             return new HelpCommand();
+
+        case TODO_COMMAND_WORD:
+            return new TodoParser().parseCommand(arguments);
 
         default:
             logger.finer("This user input caused a ParseException: " + userInput);

--- a/src/main/java/seedu/address/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/address/logic/parser/CliSyntax.java
@@ -14,4 +14,5 @@ public class CliSyntax {
     public static final Prefix PREFIX_COURSE = new Prefix("c/");
     public static final Prefix PREFIX_GROUP = new Prefix("g/");
 
+    public static final String TODO_COMMAND_WORD = "todo";
 }

--- a/src/main/java/seedu/address/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditCommandParser.java
@@ -27,25 +27,27 @@ import seedu.address.model.person.Tag;
 public class EditCommandParser implements Parser<EditCommand> {
 
     /**
-     * Parses the given {@code String} of arguments in the context of the EditCommand
-     * and returns an EditCommand object for execution.
+     * Parses the given {@code String} of arguments in the context of the EditCommand and returns an
+     * EditCommand object for execution.
+     *
      * @throws ParseException if the user input does not conform the expected format
      */
     public EditCommand parse(String args) throws ParseException {
         requireNonNull(args);
-        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_ID, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL,
-                PREFIX_TAG, PREFIX_COURSE, PREFIX_GROUP);
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_ID, PREFIX_NAME,
+                PREFIX_PHONE, PREFIX_EMAIL, PREFIX_TAG, PREFIX_COURSE, PREFIX_GROUP);
 
         Index index;
 
         try {
             index = ParserUtil.parseIndex(argMultimap.getPreamble());
         } catch (ParseException pe) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditCommand.MESSAGE_USAGE), pe);
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                    EditCommand.MESSAGE_USAGE), pe);
         }
 
         argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_ID, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL,
-            PREFIX_COURSE, PREFIX_GROUP);
+                PREFIX_COURSE, PREFIX_GROUP);
 
         EditPersonDescriptor editPersonDescriptor = new EditPersonDescriptor();
 
@@ -87,7 +89,8 @@ public class EditCommandParser implements Parser<EditCommand> {
         if (tags.isEmpty()) {
             return Optional.empty();
         }
-        Collection<String> tagSet = tags.size() == 1 && tags.contains("") ? Collections.emptySet() : tags;
+        Collection<String> tagSet = tags.size() == 1 && tags.contains("") ? Collections.emptySet()
+                : tags;
         return Optional.of(ParserUtil.parseTags(tagSet));
     }
 

--- a/src/main/java/seedu/address/logic/parser/todo/AddTodoCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/todo/AddTodoCommandParser.java
@@ -1,0 +1,64 @@
+package seedu.address.logic.parser.todo;
+
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.todo.TodoCliSyntax.PREFIX_TODO_DEADLINE;
+import static seedu.address.logic.parser.todo.TodoCliSyntax.PREFIX_TODO_LOCATION;
+import static seedu.address.logic.parser.todo.TodoCliSyntax.PREFIX_TODO_NAME;
+
+import java.util.stream.Stream;
+
+import seedu.address.logic.commands.todo.AddTodoCommand;
+import seedu.address.logic.parser.ArgumentMultimap;
+import seedu.address.logic.parser.ArgumentTokenizer;
+import seedu.address.logic.parser.Parser;
+import seedu.address.logic.parser.Prefix;
+import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.todo.Todo;
+import seedu.address.model.todo.TodoDeadline;
+import seedu.address.model.todo.TodoLocation;
+import seedu.address.model.todo.TodoName;
+
+/**
+ * Parses input arguments and creates a new AddTodoCommand object.
+ */
+public class AddTodoCommandParser implements Parser<AddTodoCommand> {
+    /**
+     * Parses the given {@code String} of arguments in the context of the AddTodoCommand and returns
+     * an AddTodoCommand object for execution.
+     *
+     * @throws ParseException if the user input does not conform the expected format.
+     */
+    public AddTodoCommand parse(String args) throws ParseException {
+        ArgumentMultimap argMultimap =
+                ArgumentTokenizer.tokenize(args, PREFIX_TODO_NAME, PREFIX_TODO_DEADLINE,
+                        PREFIX_TODO_LOCATION);
+
+        if (!arePrefixesPresent(argMultimap, PREFIX_TODO_NAME, PREFIX_TODO_DEADLINE,
+                PREFIX_TODO_LOCATION)
+                || !argMultimap.getPreamble().isEmpty()) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                    AddTodoCommand.MESSAGE_USAGE));
+        }
+
+        argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_TODO_NAME, PREFIX_TODO_DEADLINE,
+                PREFIX_TODO_LOCATION);
+        TodoName name = TodoParseUtil.parseName(argMultimap.getValue(PREFIX_TODO_NAME).get());
+        TodoDeadline deadline =
+                TodoParseUtil.parseDeadline(argMultimap.getValue(PREFIX_TODO_DEADLINE).get());
+        TodoLocation location =
+                TodoParseUtil.parseLocation(argMultimap.getValue(PREFIX_TODO_LOCATION).get());
+
+        Todo todo = new Todo(name, deadline, location);
+
+        return new AddTodoCommand(todo);
+    }
+
+    /**
+     * Returns true if none of the prefixes contains empty {@code Optional} values in the given
+     * {@code ArgumentMultimap}.
+     */
+    private static boolean arePrefixesPresent(ArgumentMultimap argumentMultimap,
+                                              Prefix... prefixes) {
+        return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/todo/TodoCliSyntax.java
+++ b/src/main/java/seedu/address/logic/parser/todo/TodoCliSyntax.java
@@ -1,0 +1,15 @@
+package seedu.address.logic.parser.todo;
+
+import seedu.address.logic.parser.Prefix;
+
+/**
+ * Contains Command Line Interface (CLI) syntax definitions common to multiple todo commands.
+ */
+public class TodoCliSyntax {
+
+    /* Prefix definitions */
+    public static final Prefix PREFIX_TODO_NAME = new Prefix("n/");
+    public static final Prefix PREFIX_TODO_DEADLINE = new Prefix("d/");
+    public static final Prefix PREFIX_TODO_LOCATION = new Prefix("l/");
+
+}

--- a/src/main/java/seedu/address/logic/parser/todo/TodoParseUtil.java
+++ b/src/main/java/seedu/address/logic/parser/todo/TodoParseUtil.java
@@ -1,0 +1,58 @@
+package seedu.address.logic.parser.todo;
+
+import static java.util.Objects.requireNonNull;
+
+import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.todo.TodoDeadline;
+import seedu.address.model.todo.TodoLocation;
+import seedu.address.model.todo.TodoName;
+
+/**
+ * Contains utility methods used for parsing strings in the various classes parsing todo commands.
+ */
+public class TodoParseUtil {
+    /**
+     * Parses a {@code String name} into a {@code TodoName}. Leading and trailing whitespaces will
+     * be trimmed.
+     *
+     * @throws ParseException if the given {@code name} is invalid.
+     */
+    public static TodoName parseName(String name) throws ParseException {
+        requireNonNull(name);
+        String trimmedName = name.trim();
+        if (!TodoName.isValid(trimmedName)) {
+            throw new ParseException(TodoName.MESSAGE_CONSTRAINTS);
+        }
+        return new TodoName(trimmedName);
+    }
+
+    /**
+     * Parses a {@code String deadline} into a {@code TodoDeadline}. Leading and trailing
+     * whitespaces will be trimmed.
+     *
+     * @throws ParseException if the given {@code deadline} is invalid.
+     */
+    public static TodoDeadline parseDeadline(String deadline) throws ParseException {
+        requireNonNull(deadline);
+        String trimmedDeadline = deadline.trim();
+        if (!TodoDeadline.isValid(trimmedDeadline)) {
+            throw new ParseException(TodoDeadline.MESSAGE_CONSTRAINTS);
+        }
+        return new TodoDeadline(trimmedDeadline);
+    }
+
+    /**
+     * Parses a {@code String location} into an {@code TodoLocation}. Leading and trailing
+     * whitespaces will be trimmed.
+     *
+     * @throws ParseException if the given {@code location} is invalid.
+     */
+    public static TodoLocation parseLocation(String location) throws ParseException {
+        requireNonNull(location);
+        String trimmedLocation = location.trim();
+        if (!TodoLocation.isValid(trimmedLocation)) {
+            throw new ParseException(TodoLocation.MESSAGE_CONSTRAINTS);
+        }
+        return new TodoLocation(trimmedLocation);
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/todo/TodoParser.java
+++ b/src/main/java/seedu/address/logic/parser/todo/TodoParser.java
@@ -1,0 +1,62 @@
+package seedu.address.logic.parser.todo;
+
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.Messages.MESSAGE_UNKNOWN_COMMAND;
+
+import java.util.logging.Logger;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import seedu.address.commons.core.LogsCenter;
+import seedu.address.logic.commands.Command;
+import seedu.address.logic.commands.HelpCommand;
+import seedu.address.logic.commands.todo.AddTodoCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+
+/**
+ * Parses user input for todo commands.
+ */
+public class TodoParser {
+
+    /**
+     * Used for initial separation of command word and args.
+     */
+    private static final Pattern BASIC_COMMAND_FORMAT =
+            Pattern.compile("(?<commandWord>\\S+)(?<arguments>.*)");
+    private static final Logger logger = LogsCenter.getLogger(TodoParser.class);
+
+    /**
+     * Parses user input into command for execution.
+     *
+     * @param userInput full user input string
+     * @return the command based on the user input
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public Command parseCommand(String userInput) throws ParseException {
+        final Matcher matcher = BASIC_COMMAND_FORMAT.matcher(userInput.trim());
+        if (!matcher.matches()) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                    HelpCommand.MESSAGE_USAGE));
+        }
+
+        final String commandWord = matcher.group("commandWord");
+        final String arguments = matcher.group("arguments");
+
+        // Note to developers: Change the log level in config.json to enable lower level (i.e.,
+        // FINE, FINER and lower)
+        // log messages such as the one below.
+        // Lower level log messages are used sparingly to minimize noise in the code.
+        logger.fine("Command word: " + commandWord + "; Arguments: " + arguments);
+
+        switch (commandWord) {
+
+        case AddTodoCommand.COMMAND_WORD:
+            return new AddTodoCommandParser().parse(arguments);
+
+        default:
+            logger.finer("This user input caused a ParseException: " + userInput);
+            throw new ParseException(MESSAGE_UNKNOWN_COMMAND);
+        }
+    }
+
+}

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -5,7 +5,9 @@ import java.util.function.Predicate;
 
 import javafx.collections.ObservableList;
 import seedu.address.commons.core.GuiSettings;
+import seedu.address.model.item.ItemManagerWithFilteredList;
 import seedu.address.model.person.Person;
+import seedu.address.model.todo.Todo;
 
 /**
  * The API of the Model component.
@@ -84,4 +86,9 @@ public interface Model {
      * @throws NullPointerException if {@code predicate} is null.
      */
     void updateFilteredPersonList(Predicate<Person> predicate);
+
+    /**
+     * Returns the todo manager and display list.
+     */
+    ItemManagerWithFilteredList<Todo> getTodoManagerAndList();
 }

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -11,7 +11,10 @@ import javafx.collections.ObservableList;
 import javafx.collections.transformation.FilteredList;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.commons.core.LogsCenter;
+import seedu.address.model.item.ItemManagerWithFilteredList;
 import seedu.address.model.person.Person;
+import seedu.address.model.todo.Todo;
+import seedu.address.model.todo.TodoMangerWithFilteredList;
 
 /**
  * Represents the in-memory model of the address book data.
@@ -22,6 +25,8 @@ public class ModelManager implements Model {
     private final AddressBook addressBook;
     private final UserPrefs userPrefs;
     private final FilteredList<Person> filteredPersons;
+
+    private final ItemManagerWithFilteredList<Todo> todoManagerAndList;
 
     /**
      * Initializes a ModelManager with the given addressBook and userPrefs.
@@ -34,6 +39,8 @@ public class ModelManager implements Model {
         this.addressBook = new AddressBook(addressBook);
         this.userPrefs = new UserPrefs(userPrefs);
         filteredPersons = new FilteredList<>(this.addressBook.getPersonList());
+
+        todoManagerAndList = new TodoMangerWithFilteredList();
     }
 
     public ModelManager() {
@@ -126,6 +133,11 @@ public class ModelManager implements Model {
     public void updateFilteredPersonList(Predicate<Person> predicate) {
         requireNonNull(predicate);
         filteredPersons.setPredicate(predicate);
+    }
+
+    @Override
+    public ItemManagerWithFilteredList<Todo> getTodoManagerAndList() {
+        return todoManagerAndList;
     }
 
     @Override

--- a/src/main/java/seedu/address/model/todo/Todo.java
+++ b/src/main/java/seedu/address/model/todo/Todo.java
@@ -1,0 +1,79 @@
+package seedu.address.model.todo;
+
+import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
+
+import java.util.Objects;
+
+import seedu.address.commons.util.ToStringBuilder;
+import seedu.address.model.item.Item;
+
+/**
+ * Represents a Todo.
+ * Guarantees: details are present and not null, field values are validated, immutable.
+ */
+public class Todo implements Item {
+
+    // Identity fields
+    private final TodoName name;
+
+    // Data fields
+    private final TodoDeadline deadline;
+    private final TodoLocation location;
+
+    /**
+     * Every field must be present and not null.
+     */
+    public Todo(TodoName name, TodoDeadline deadline, TodoLocation location) {
+        requireAllNonNull(name, deadline, location);
+        this.name = name;
+        this.deadline = deadline;
+        this.location = location;
+    }
+
+    public TodoName getName() {
+        return name;
+    }
+
+    public TodoDeadline getDeadline() {
+        return deadline;
+    }
+
+    public TodoLocation getLocation() {
+        return location;
+    }
+
+    /**
+     * Returns true if both todos have the same identity and data fields.
+     * This defines a stronger notion of equality between two todos.
+     */
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof Todo otherTodo)) {
+            return false;
+        }
+
+        return name.equals(otherTodo.name)
+                && deadline.equals(otherTodo.deadline)
+                && location.equals(otherTodo.location);
+    }
+
+    @Override
+    public int hashCode() {
+        // use this method for custom fields hashing instead of implementing your own
+        return Objects.hash(name, deadline, location);
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this)
+                .add("name", name)
+                .add("deadline", deadline)
+                .add("location", location)
+                .toString();
+    }
+}

--- a/src/main/java/seedu/address/model/todo/TodoDeadline.java
+++ b/src/main/java/seedu/address/model/todo/TodoDeadline.java
@@ -1,0 +1,70 @@
+package seedu.address.model.todo;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.util.AppUtil.checkArgument;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+
+/**
+ * Represents a Todo's deadline.
+ * Guarantees: immutable; is valid as declared in {@link #isValid(String)}
+ */
+public class TodoDeadline {
+
+    public static final String MESSAGE_CONSTRAINTS =
+            "Deadline should be in the format YY-MM-DD HH:MM, where HH is in 24-hour format.";
+
+    public static final DateTimeFormatter DATE_TIME_FORMATTER =
+            DateTimeFormatter.ofPattern("yy-MM-dd HH:mm");
+
+    public final LocalDateTime deadline;
+
+    /**
+     * Constructs a {@code TodoDeadline}.
+     *
+     * @param deadline A valid deadline in the format "YY-MM-DD HH:MM".
+     */
+    public TodoDeadline(String deadline) {
+        requireNonNull(deadline);
+        checkArgument(isValid(deadline), MESSAGE_CONSTRAINTS);
+        this.deadline = LocalDateTime.parse(deadline, DATE_TIME_FORMATTER);
+    }
+
+    /**
+     * Returns true if a given string is a valid deadline.
+     */
+    public static boolean isValid(String test) {
+        try {
+            LocalDateTime.parse(test, DATE_TIME_FORMATTER);
+            return true;
+        } catch (DateTimeParseException e) {
+            return false;
+        }
+    }
+
+    @Override
+    public String toString() {
+        return deadline.format(DATE_TIME_FORMATTER);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof TodoDeadline otherDeadline)) {
+            return false;
+        }
+
+        return deadline.equals(otherDeadline.deadline);
+    }
+
+    @Override
+    public int hashCode() {
+        return deadline.hashCode();
+    }
+}

--- a/src/main/java/seedu/address/model/todo/TodoDuplicateChecker.java
+++ b/src/main/java/seedu/address/model/todo/TodoDuplicateChecker.java
@@ -1,0 +1,13 @@
+package seedu.address.model.todo;
+
+import seedu.address.model.item.DuplicateChecker;
+
+/**
+ * Checks if two given todos are considered duplicates of each other.
+ */
+public class TodoDuplicateChecker implements DuplicateChecker<Todo> {
+    @Override
+    public boolean check(Todo first, Todo second) {
+        return first == second || (first != null && first.getName().equals(second.getName()));
+    }
+}

--- a/src/main/java/seedu/address/model/todo/TodoLocation.java
+++ b/src/main/java/seedu/address/model/todo/TodoLocation.java
@@ -1,0 +1,65 @@
+package seedu.address.model.todo;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.util.AppUtil.checkArgument;
+
+/**
+ * Represents a Todo's location in the address book.
+ * Guarantees: immutable; is valid as declared in {@link #isValid(String)}
+ */
+public class TodoLocation {
+
+    public static final String MESSAGE_CONSTRAINTS =
+            "Locations can take any values, and it should not be blank";
+
+    /*
+     * The first character of the address must not be a whitespace,
+     * otherwise " " (a blank string) becomes a valid input.
+     */
+    public static final String VALIDATION_REGEX = "[^\\s].*";
+
+    public final String value;
+
+    /**
+     * Constructs an {@code TodoLocation}.
+     *
+     * @param address A valid address.
+     */
+    public TodoLocation(String address) {
+        requireNonNull(address);
+        checkArgument(isValid(address), MESSAGE_CONSTRAINTS);
+        value = address;
+    }
+
+    /**
+     * Returns true if a given string is a valid location.
+     */
+    public static boolean isValid(String test) {
+        return test.matches(VALIDATION_REGEX);
+    }
+
+    @Override
+    public String toString() {
+        return value;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof TodoLocation otherLocation)) {
+            return false;
+        }
+
+        return value.equals(otherLocation.value);
+    }
+
+    @Override
+    public int hashCode() {
+        return value.hashCode();
+    }
+
+}

--- a/src/main/java/seedu/address/model/todo/TodoManager.java
+++ b/src/main/java/seedu/address/model/todo/TodoManager.java
@@ -1,0 +1,12 @@
+package seedu.address.model.todo;
+
+import seedu.address.model.item.ItemManager;
+
+/**
+ * Wraps all {@code Todo}-related data. Duplicates are not allowed.
+ */
+public class TodoManager extends ItemManager<Todo> {
+    public TodoManager() {
+        super(new UniqueTodoList());
+    }
+}

--- a/src/main/java/seedu/address/model/todo/TodoMangerWithFilteredList.java
+++ b/src/main/java/seedu/address/model/todo/TodoMangerWithFilteredList.java
@@ -1,0 +1,13 @@
+package seedu.address.model.todo;
+
+import seedu.address.model.item.ItemManagerWithFilteredList;
+
+/**
+ * Manages a list of {@code Todo} objects and provides a filtered list for display purposes.
+ * Duplicates are not allowed in the underlying list.
+ */
+public class TodoMangerWithFilteredList extends ItemManagerWithFilteredList<Todo> {
+    public TodoMangerWithFilteredList() {
+        super(new TodoManager());
+    }
+}

--- a/src/main/java/seedu/address/model/todo/TodoName.java
+++ b/src/main/java/seedu/address/model/todo/TodoName.java
@@ -1,0 +1,66 @@
+package seedu.address.model.todo;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.util.AppUtil.checkArgument;
+
+/**
+ * Represents a Todo's name. Guarantees: immutable; is valid as declared in
+ * {@link #isValid(String)}
+ */
+public class TodoName {
+
+    public static final String MESSAGE_CONSTRAINTS =
+            "Names should only contain alphanumeric characters and spaces, and it should not be " +
+                    "blank";
+
+    /*
+     * The first character of the address must not be a whitespace,
+     * otherwise " " (a blank string) becomes a valid input.
+     */
+    public static final String VALIDATION_REGEX = "[\\p{Alnum}][\\p{Alnum} ]*";
+
+    public final String name;
+
+    /**
+     * Constructs a {@code Name}.
+     *
+     * @param name A valid name.
+     */
+    public TodoName(String name) {
+        requireNonNull(name);
+        checkArgument(isValid(name), MESSAGE_CONSTRAINTS);
+        this.name = name;
+    }
+
+    /**
+     * Returns true if a given string is a valid name.
+     */
+    public static boolean isValid(String test) {
+        return test.matches(VALIDATION_REGEX);
+    }
+
+
+    @Override
+    public String toString() {
+        return name;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof TodoName otherName)) {
+            return false;
+        }
+
+        return name.equals(otherName.name);
+    }
+
+    @Override
+    public int hashCode() {
+        return name.hashCode();
+    }
+}

--- a/src/main/java/seedu/address/model/todo/TodoName.java
+++ b/src/main/java/seedu/address/model/todo/TodoName.java
@@ -10,8 +10,7 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
 public class TodoName {
 
     public static final String MESSAGE_CONSTRAINTS =
-            "Names should only contain alphanumeric characters and spaces, and it should not be " +
-                    "blank";
+            "Names should only contain alphanumeric characters and spaces, and it should not be blank";
 
     /*
      * The first character of the address must not be a whitespace,

--- a/src/main/java/seedu/address/model/todo/UniqueTodoList.java
+++ b/src/main/java/seedu/address/model/todo/UniqueTodoList.java
@@ -1,0 +1,26 @@
+package seedu.address.model.todo;
+
+import seedu.address.model.item.UniqueItemList;
+import seedu.address.model.todo.exceptions.DuplicateTodoException;
+import seedu.address.model.todo.exceptions.TodoNotFoundException;
+
+/**
+ * A list of todos that enforces uniqueness between its elements and does not allow nulls.
+ * Supports a minimal set of list operations.
+ */
+public class UniqueTodoList extends UniqueItemList<Todo> {
+
+    public UniqueTodoList() {
+        super(new TodoDuplicateChecker());
+    }
+
+    @Override
+    public void throwDuplicateException() {
+        throw new DuplicateTodoException();
+    }
+
+    @Override
+    public void throwNotFoundException() {
+        throw new TodoNotFoundException();
+    }
+}

--- a/src/main/java/seedu/address/model/todo/exceptions/DuplicateTodoException.java
+++ b/src/main/java/seedu/address/model/todo/exceptions/DuplicateTodoException.java
@@ -1,0 +1,11 @@
+package seedu.address.model.todo.exceptions;
+
+/**
+ * Signals that the operation will result in duplicate Todos (Todos are considered duplicates if
+ * they have the same identity).
+ */
+public class DuplicateTodoException extends RuntimeException {
+    public DuplicateTodoException() {
+        super("Operation would result in duplicate todos");
+    }
+}

--- a/src/main/java/seedu/address/model/todo/exceptions/TodoNotFoundException.java
+++ b/src/main/java/seedu/address/model/todo/exceptions/TodoNotFoundException.java
@@ -1,0 +1,6 @@
+package seedu.address.model.todo.exceptions;
+
+/**
+ * Signals that the operation is unable to find the specified todo.
+ */
+public class TodoNotFoundException extends RuntimeException {}

--- a/src/main/java/seedu/address/model/util/SampleDataUtil.java
+++ b/src/main/java/seedu/address/model/util/SampleDataUtil.java
@@ -8,8 +8,8 @@ import seedu.address.model.AddressBook;
 import seedu.address.model.ReadOnlyAddressBook;
 import seedu.address.model.person.Course;
 import seedu.address.model.person.Email;
-import seedu.address.model.person.Id;
 import seedu.address.model.person.Group;
+import seedu.address.model.person.Id;
 import seedu.address.model.person.Name;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.Phone;
@@ -21,29 +21,30 @@ import seedu.address.model.person.Tag;
 public class SampleDataUtil {
     public static Person[] getSamplePersons() {
         return new Person[]{
-            new Person(new Id("A0123456X"), new Name("Alex Yeoh"), new Phone("87438807"), new Email("alexyeoh@example.com"),
-                new Course("CS1010S"), new Group("T01"),
-                getTagSet("friends")),
+            new Person(new Id("A0123456X"), new Name("Alex Yeoh"), new Phone("87438807"),
+                    new Email("alexyeoh@example.com"),
+                    new Course("CS1010S"), new Group("T01"),
+                    getTagSet("friends")),
             new Person(new Id("A1234567Y"), new Name("Bernice Yu"), new Phone("99272758"),
-                new Email("berniceyu@example.com"),
-                new Course("CS1010S"), new Group("R01"),
-                getTagSet("colleagues", "friends")),
+                    new Email("berniceyu@example.com"),
+                    new Course("CS1010S"), new Group("R01"),
+                    getTagSet("colleagues", "friends")),
             new Person(new Id("A2345678Z"), new Name("Charlotte Oliveiro"),
-                new Phone("93210283"), new Email("charlotte@example.com"),
-                new Course("CS2103"), new Group("F08"),
-                getTagSet("neighbours")),
+                    new Phone("93210283"), new Email("charlotte@example.com"),
+                    new Course("CS2103"), new Group("F08"),
+                    getTagSet("neighbours")),
             new Person(new Id("A3456789G"), new Name("David Li"), new Phone("91031282"),
-                new Email("lidavid@example.com"),
-                new Course("CS2030"), new Group("F10"),
-                getTagSet("family")),
+                    new Email("lidavid@example.com"),
+                    new Course("CS2030"), new Group("F10"),
+                    getTagSet("family")),
             new Person(new Id("A4567890H"), new Name("Irfan Ibrahim"), new Phone("92492021"),
-                new Email("irfan@example.com"),
-                new Course("CS2040"), new Group("T10"),
-                getTagSet("classmates")),
+                    new Email("irfan@example.com"),
+                    new Course("CS2040"), new Group("T10"),
+                    getTagSet("classmates")),
             new Person(new Id("A5678901K"), new Name("Roy Balakrishnan"), new Phone("92624417"),
-                new Email("royb@example.com"),
-                new Course("CS1010S"), new Group("T28"),
-                getTagSet("colleagues"))
+                    new Email("royb@example.com"),
+                    new Course("CS1010S"), new Group("T28"),
+                    getTagSet("colleagues"))
         };
     }
 

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -32,6 +32,7 @@ public class MainWindow extends UiPart<Stage> {
 
     // Independent Ui parts residing in this Ui container
     private PersonListPanel personListPanel;
+    private TodoListPanel todoListPanel;
     private ResultDisplay resultDisplay;
     private HelpWindow helpWindow;
 
@@ -43,6 +44,9 @@ public class MainWindow extends UiPart<Stage> {
 
     @FXML
     private StackPane personListPanelPlaceholder;
+
+    @FXML
+    private StackPane todoListPanelPlaceholder;
 
     @FXML
     private StackPane resultDisplayPlaceholder;
@@ -112,6 +116,9 @@ public class MainWindow extends UiPart<Stage> {
     void fillInnerParts() {
         personListPanel = new PersonListPanel(logic.getFilteredPersonList());
         personListPanelPlaceholder.getChildren().add(personListPanel.getRoot());
+
+        todoListPanel = new TodoListPanel(logic.getFilteredTodoList());
+        todoListPanelPlaceholder.getChildren().add(todoListPanel.getRoot());
 
         resultDisplay = new ResultDisplay();
         resultDisplayPlaceholder.getChildren().add(resultDisplay.getRoot());

--- a/src/main/java/seedu/address/ui/TodoCard.java
+++ b/src/main/java/seedu/address/ui/TodoCard.java
@@ -1,0 +1,37 @@
+package seedu.address.ui;
+
+import javafx.fxml.FXML;
+import javafx.scene.control.Label;
+import javafx.scene.layout.HBox;
+import javafx.scene.layout.Region;
+import seedu.address.model.todo.Todo;
+
+public class TodoCard extends UiPart<Region> {
+
+    private static final String FXML = "TodoListCard.fxml";
+
+    public final Todo todo;
+
+    @javafx.fxml.FXML
+    private HBox cardPane;
+    @FXML
+    private Label name;
+    @FXML
+    private Label id;
+    @FXML
+    private Label deadline;
+    @FXML
+    private Label todoLocation;
+
+    /**
+     * Creates a {@code TodoCard} with the given {@code todo} and index to display.
+     */
+    public TodoCard(Todo todo, int displayedIndex) {
+        super(FXML);
+        this.todo = todo;
+        id.setText(displayedIndex + ". ");
+        name.setText(todo.getName().name);
+        deadline.setText(todo.getDeadline().toString());
+        todoLocation.setText(todo.getLocation().value);
+    }
+}

--- a/src/main/java/seedu/address/ui/TodoCard.java
+++ b/src/main/java/seedu/address/ui/TodoCard.java
@@ -6,6 +6,9 @@ import javafx.scene.layout.HBox;
 import javafx.scene.layout.Region;
 import seedu.address.model.todo.Todo;
 
+/**
+ * An UI component that displays information of a {@code Todo}.
+ */
 public class TodoCard extends UiPart<Region> {
 
     private static final String FXML = "TodoListCard.fxml";

--- a/src/main/java/seedu/address/ui/TodoListPanel.java
+++ b/src/main/java/seedu/address/ui/TodoListPanel.java
@@ -1,0 +1,48 @@
+package seedu.address.ui;
+
+import java.util.logging.Logger;
+
+import javafx.collections.ObservableList;
+import javafx.fxml.FXML;
+import javafx.scene.control.ListCell;
+import javafx.scene.control.ListView;
+import javafx.scene.layout.Region;
+import seedu.address.commons.core.LogsCenter;
+import seedu.address.model.todo.Todo;
+
+public class TodoListPanel extends UiPart<Region> {
+
+    private static final String FXML = "TodoListPanel.fxml";
+    private final Logger logger = LogsCenter.getLogger(TodoListPanel.class);
+
+    @FXML
+    private ListView<Todo> todoListView;
+
+    /**
+     * Creates a {@code PersonListPanel} with the given {@code ObservableList}.
+     */
+    public TodoListPanel(ObservableList<Todo> todoList) {
+        super(FXML);
+        todoListView.setItems(todoList);
+        todoListView.setCellFactory(listView -> new TodoListViewCell());
+    }
+
+    /**
+     * Custom {@code ListCell} that displays the graphics of a {@code Todo} using a
+     * {@code TodoCard}.
+     */
+    class TodoListViewCell extends ListCell<Todo> {
+        @Override
+        protected void updateItem(Todo todo, boolean empty) {
+            super.updateItem(todo, empty);
+
+            if (empty || todo == null) {
+                setGraphic(null);
+                setText(null);
+            } else {
+                setGraphic(new TodoCard(todo, getIndex() + 1).getRoot());
+            }
+        }
+    }
+
+}

--- a/src/main/java/seedu/address/ui/TodoListPanel.java
+++ b/src/main/java/seedu/address/ui/TodoListPanel.java
@@ -10,6 +10,9 @@ import javafx.scene.layout.Region;
 import seedu.address.commons.core.LogsCenter;
 import seedu.address.model.todo.Todo;
 
+/**
+ * Panel containing the list of todos.
+ */
 public class TodoListPanel extends UiPart<Region> {
 
     private static final String FXML = "TodoListPanel.fxml";

--- a/src/main/resources/view/MainWindow.fxml
+++ b/src/main/resources/view/MainWindow.fxml
@@ -53,6 +53,14 @@
           <StackPane fx:id="personListPanelPlaceholder" VBox.vgrow="ALWAYS"/>
         </VBox>
 
+        <VBox fx:id="todoList" styleClass="pane-with-border" minWidth="340" prefWidth="340"
+              VBox.vgrow="ALWAYS">
+          <padding>
+            <Insets top="10" right="10" bottom="10" left="10" />
+          </padding>
+          <StackPane fx:id="todoListPanelPlaceholder" VBox.vgrow="ALWAYS"/>
+        </VBox>
+
         <StackPane fx:id="statusbarPlaceholder" VBox.vgrow="NEVER" />
       </VBox>
     </Scene>

--- a/src/main/resources/view/TodoListCard.fxml
+++ b/src/main/resources/view/TodoListCard.fxml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<?import javafx.geometry.Insets?>
+<?import javafx.scene.control.Label?>
+<?import javafx.scene.layout.ColumnConstraints?>
+<?import javafx.scene.layout.GridPane?>
+<?import javafx.scene.layout.HBox?>
+<?import javafx.scene.layout.Region?>
+<?import javafx.scene.layout.VBox?>
+
+<HBox id="cardPane" fx:id="cardPane" xmlns="http://javafx.com/javafx/17" xmlns:fx="http://javafx.com/fxml/1">
+    <GridPane HBox.hgrow="ALWAYS">
+        <columnConstraints>
+            <ColumnConstraints hgrow="SOMETIMES" minWidth="10" prefWidth="150" />
+        </columnConstraints>
+        <VBox alignment="CENTER_LEFT" minHeight="105" GridPane.columnIndex="0">
+            <padding>
+                <Insets top="5" right="5" bottom="5" left="15" />
+            </padding>
+            <HBox spacing="0.5" alignment="CENTER_LEFT">
+                <Label fx:id="id" styleClass="cell_big_label">
+                    <minWidth>
+                        <!-- Ensures that the label text is never truncated -->
+                        <Region fx:constant="USE_PREF_SIZE" />
+                    </minWidth>
+                </Label>
+                <Label fx:id="name" text="\$first" styleClass="cell_big_label" />
+            </HBox>
+            <Label fx:id="deadline" styleClass="cell_small_label" text="\$deadline" />
+            <Label fx:id="todoLocation" styleClass="cell_small_label" text="\$todoLocation" />
+        </VBox>
+    </GridPane>
+</HBox>

--- a/src/main/resources/view/TodoListPanel.fxml
+++ b/src/main/resources/view/TodoListPanel.fxml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<?import javafx.scene.control.ListView?>
+<?import javafx.scene.layout.VBox?>
+
+<VBox xmlns="http://javafx.com/javafx/17" xmlns:fx="http://javafx.com/fxml/1">
+    <ListView fx:id="todoListView" VBox.vgrow="ALWAYS" />
+</VBox>

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -22,7 +22,9 @@ import seedu.address.model.AddressBook;
 import seedu.address.model.Model;
 import seedu.address.model.ReadOnlyAddressBook;
 import seedu.address.model.ReadOnlyUserPrefs;
+import seedu.address.model.item.ItemManagerWithFilteredList;
 import seedu.address.model.person.Person;
+import seedu.address.model.todo.Todo;
 import seedu.address.testutil.PersonBuilder;
 
 public class AddCommandTest {
@@ -155,6 +157,11 @@ public class AddCommandTest {
 
         @Override
         public void updateFilteredPersonList(Predicate<Person> predicate) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public ItemManagerWithFilteredList<Todo> getTodoManagerAndList() {
             throw new AssertionError("This method should not be called.");
         }
     }


### PR DESCRIPTION
Add support for tracking todos. A todo currently has 3 fields:

- Name. Must be unique (need more discussion on how to distinguish between todos).
- Deadline. Must be in YY-MM-DD HH:MM format.
- Location.

Add a command to add a todo. The format is `todo add n/<name> d/<deadline> l/<location>`. Example: `todo add n/Hello World d/25-12-03 12:11 l/NUS Science`.

Add a simple UI to display todos, which is a list below the contact list. This should be changed in the future.

Will add tests in the future.

Resolves #77