### PR TITLE
[#94][#95] Support adding and removing contacts to todos

### DIFF
--- a/src/main/java/seedu/address/commons/core/index/Index.java
+++ b/src/main/java/seedu/address/commons/core/index/Index.java
@@ -66,4 +66,9 @@ public class Index {
     public String toString() {
         return new ToStringBuilder(this).add("zeroBasedIndex", zeroBasedIndex).toString();
     }
+
+    @Override
+    public int hashCode() {
+        return Integer.hashCode(zeroBasedIndex);
+    }
 }

--- a/src/main/java/seedu/address/logic/Messages.java
+++ b/src/main/java/seedu/address/logic/Messages.java
@@ -66,7 +66,7 @@ public class Messages {
         if (todo.getPersons().isEmpty()) {
             personsFormatted = "None";
         } else {
-            personsFormatted = "\n" + IntStream.range(0, todo.getPersons().size())
+            personsFormatted = IntStream.range(0, todo.getPersons().size())
                     .mapToObj(i -> (i + 1) + ". " + getSimplifiedFormat(todo.getPersons().get(i)))
                     .collect(Collectors.joining("\n"));
         }
@@ -74,7 +74,7 @@ public class Messages {
         return todo.getName()
                 + "; Deadline: " + todo.getDeadline()
                 + "; Location: " + todo.getLocation()
-                + "; Persons: " + personsFormatted;
+                + "; Persons:" + (todo.getPersons().isEmpty() ? " " : "\n") + personsFormatted;
     }
 
     /**

--- a/src/main/java/seedu/address/logic/Messages.java
+++ b/src/main/java/seedu/address/logic/Messages.java
@@ -2,6 +2,7 @@ package seedu.address.logic;
 
 import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
 import seedu.address.logic.parser.Prefix;
@@ -57,13 +58,35 @@ public class Messages {
     }
 
     /**
+     * Returns a simplified format of a {@code person} for display to the user.
+     */
+    public static String getSimplifiedFormat(Person person) {
+        return person.getName()
+                + "; ID: " + person.getId()
+                + "; Course: " + person.getCourse()
+                + "; Group: " + person.getGroup();
+    }
+
+    /**
      * Formats the {@code todo} for display to the user.
      */
     public static String format(Todo todo) {
+        String personsFormatted;
+
+        if (todo.getPersons().isEmpty()) {
+            personsFormatted = "None";
+        } else {
+            personsFormatted = IntStream.range(0, todo.getPersons().size())
+                    .mapToObj(i -> (i + 1) + ". " + getSimplifiedFormat(todo.getPersons().get(i)))
+                    .collect(Collectors.joining("\n"));
+        }
+
         return todo.getName()
                 + "; Deadline: " + todo.getDeadline()
-                + "; Location: " + todo.getLocation();
+                + "; Location: " + todo.getLocation()
+                + "; Persons:\n" + personsFormatted;
     }
+
     /**
      * Formats the {@code todo} for display to the user.
      */

--- a/src/main/java/seedu/address/logic/Messages.java
+++ b/src/main/java/seedu/address/logic/Messages.java
@@ -58,16 +58,6 @@ public class Messages {
     }
 
     /**
-     * Returns a simplified format of a {@code person} for display to the user.
-     */
-    public static String getSimplifiedFormat(Person person) {
-        return person.getName()
-                + "; ID: " + person.getId()
-                + "; Course: " + person.getCourse()
-                + "; Group: " + person.getGroup();
-    }
-
-    /**
      * Formats the {@code todo} for display to the user.
      */
     public static String format(Todo todo) {
@@ -76,7 +66,7 @@ public class Messages {
         if (todo.getPersons().isEmpty()) {
             personsFormatted = "None";
         } else {
-            personsFormatted = IntStream.range(0, todo.getPersons().size())
+            personsFormatted = "\n" + IntStream.range(0, todo.getPersons().size())
                     .mapToObj(i -> (i + 1) + ". " + getSimplifiedFormat(todo.getPersons().get(i)))
                     .collect(Collectors.joining("\n"));
         }
@@ -84,7 +74,7 @@ public class Messages {
         return todo.getName()
                 + "; Deadline: " + todo.getDeadline()
                 + "; Location: " + todo.getLocation()
-                + "; Persons:\n" + personsFormatted;
+                + "; Persons: " + personsFormatted;
     }
 
     /**
@@ -95,5 +85,15 @@ public class Messages {
                 + "; Start Time: " + event.getStartTime()
                 + "; End Time: " + event.getEndTime()
                 + "; Location: " + event.getLocation();
+    }
+
+    /**
+     * Returns a simplified format of a {@code person} for display to the user.
+     */
+    public static String getSimplifiedFormat(Person person) {
+        return person.getName()
+                + "; ID: " + person.getId()
+                + "; Course: " + person.getCourse()
+                + "; Group: " + person.getGroup();
     }
 }

--- a/src/main/java/seedu/address/logic/abstractcommand/EditCommand.java
+++ b/src/main/java/seedu/address/logic/abstractcommand/EditCommand.java
@@ -45,7 +45,7 @@ public abstract class EditCommand<T extends Item> extends ItemCommand<T> {
         }
 
         T itemToEdit = lastShownList.get(index.getZeroBased());
-        T editedItem = createEditedItem(itemToEdit);
+        T editedItem = createEditedItem(model, itemToEdit);
 
         if (!managerAndList.getDuplicateChecker().check(itemToEdit, editedItem)
                 && managerAndList.hasItem(editedItem)) {
@@ -60,7 +60,7 @@ public abstract class EditCommand<T extends Item> extends ItemCommand<T> {
     /**
      * Creates an edited version of the given item to be applied to the list.
      */
-    public abstract T createEditedItem(T itemToEdit);
+    public abstract T createEditedItem(Model model, T itemToEdit) throws CommandException;
 
     /**
      * Returns the message to be displayed when the provided index is invalid.

--- a/src/main/java/seedu/address/logic/commands/person/EditPersonCommand.java
+++ b/src/main/java/seedu/address/logic/commands/person/EditPersonCommand.java
@@ -74,7 +74,7 @@ public class EditPersonCommand extends EditCommand<Person> {
      * Creates and returns a {@code Person} with the details of {@code personToEdit} edited with
      * {@code editPersonDescriptor}.
      */
-    public Person createEditedItem(Person personToEdit) {
+    public Person createEditedItem(Model model, Person personToEdit) {
         assert personToEdit != null;
 
         Id updatedId = editPersonDescriptor.getId().orElse(personToEdit.getId());

--- a/src/main/java/seedu/address/logic/commands/todo/AddPersonToTodoCommand.java
+++ b/src/main/java/seedu/address/logic/commands/todo/AddPersonToTodoCommand.java
@@ -17,19 +17,22 @@ import seedu.address.model.item.ItemManagerWithFilteredList;
 import seedu.address.model.person.Person;
 import seedu.address.model.todo.Todo;
 
+/**
+ * Associate a list of persons to a todo.
+ */
 public class AddPersonToTodoCommand extends EditCommand<Todo> {
 
     public static final String COMMAND_WORD = "link";
 
     public static final String MESSAGE_USAGE = TODO_COMMAND_WORD + " " + COMMAND_WORD
-            + ": Description\n"
+            + ": Associate a todo with some contacts.\n"
             + "Parameters: INDEX"
             + PREFIX_LINKED_PERSON_INDEX + "[PERSON_INDEX]...\n"
             + "Example: " + TODO_COMMAND_WORD + " " + COMMAND_WORD + " 1 "
             + PREFIX_LINKED_PERSON_INDEX + " 1 3 4";
 
     public static final String MESSAGE_INVALID_PERSON_DISPLAYED_INDEX =
-            "The person index provided is invalid";
+            "The person index provided is invalid: %1$s";
     public static final String MESSAGE_INVALID_TODO_DISPLAYED_INDEX =
             "The todo index provided is invalid";
     public static final String MESSAGE_ADD_PERSON_SUCCESS = "Added persons to todo: %1$s";
@@ -42,6 +45,10 @@ public class AddPersonToTodoCommand extends EditCommand<Todo> {
     private final Function<Model, ItemManagerWithFilteredList<Person>>
             personManagerAndListGetter = Model::getPersonManagerAndList;
 
+    /**
+     * Creates an AddPersonToTodoCommand to add the persons at the specified {@code personIndices}
+     * to the todo at the specified {@code index}.
+     */
     public AddPersonToTodoCommand(Index index, List<Index> personIndices) {
         super(index, Model::getTodoManagerAndList);
         requireNonNull(personIndices);
@@ -55,7 +62,8 @@ public class AddPersonToTodoCommand extends EditCommand<Todo> {
 
         for (Index index : personIndices) {
             if (index.getZeroBased() >= filteredPersons.size()) {
-                throw new CommandException(MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+                throw new CommandException(String.format(MESSAGE_INVALID_PERSON_DISPLAYED_INDEX,
+                        index.getOneBased()));
             }
         }
 

--- a/src/main/java/seedu/address/logic/commands/todo/AddPersonToTodoCommand.java
+++ b/src/main/java/seedu/address/logic/commands/todo/AddPersonToTodoCommand.java
@@ -1,0 +1,97 @@
+package seedu.address.logic.commands.todo;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.parser.CliSyntax.TODO_COMMAND_WORD;
+import static seedu.address.logic.parser.todo.TodoCliSyntax.PREFIX_LINKED_PERSON_INDEX;
+
+import java.util.List;
+import java.util.function.Function;
+import java.util.stream.Stream;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.Messages;
+import seedu.address.logic.abstractcommand.EditCommand;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.item.ItemManagerWithFilteredList;
+import seedu.address.model.person.Person;
+import seedu.address.model.todo.Todo;
+
+public class AddPersonToTodoCommand extends EditCommand<Todo> {
+
+    public static final String COMMAND_WORD = "link";
+
+    public static final String MESSAGE_USAGE = TODO_COMMAND_WORD + " " + COMMAND_WORD
+            + ": Description\n"
+            + "Parameters: INDEX"
+            + PREFIX_LINKED_PERSON_INDEX + "[PERSON_INDEX]...\n"
+            + "Example: " + TODO_COMMAND_WORD + " " + COMMAND_WORD + " 1 "
+            + PREFIX_LINKED_PERSON_INDEX + " 1 3 4";
+
+    public static final String MESSAGE_INVALID_PERSON_DISPLAYED_INDEX =
+            "The person index provided is invalid";
+    public static final String MESSAGE_INVALID_TODO_DISPLAYED_INDEX =
+            "The todo index provided is invalid";
+    public static final String MESSAGE_ADD_PERSON_SUCCESS = "Added persons to todo: %1$s";
+    public static final String MESSAGE_NOT_ADDED = "At least one person must be provided.";
+    public static final String MESSAGE_DUPLICATE_PERSON =
+            "Person %1$s is already assigned to this todo.";
+    public static final String MESSAGE_DUPLICATE_TODO = "This todo already exists";
+
+    private final List<Index> personIndices;
+    private final Function<Model, ItemManagerWithFilteredList<Person>>
+            personManagerAndListGetter = Model::getPersonManagerAndList;
+
+    public AddPersonToTodoCommand(Index index, List<Index> personIndices) {
+        super(index, Model::getTodoManagerAndList);
+        requireNonNull(personIndices);
+        this.personIndices = personIndices;
+    }
+
+    @Override
+    public Todo createEditedItem(Model model, Todo itemToEdit) throws CommandException {
+        List<Person> filteredPersons = personManagerAndListGetter.apply(model)
+                .getFilteredItemsList();
+
+        for (Index index : personIndices) {
+            if (index.getZeroBased() >= filteredPersons.size()) {
+                throw new CommandException(MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+            }
+        }
+
+        List<Person> addedPersons = personIndices.stream()
+                .map(index -> filteredPersons.get(index.getZeroBased())).toList();
+
+        for (Person person : addedPersons) {
+            if (itemToEdit.getPersons().contains(person)) {
+                throw new CommandException(String.format(MESSAGE_DUPLICATE_PERSON,
+                        Messages.getSimplifiedFormat(person)));
+            }
+        }
+
+        List<Person> combinedPersons =
+                Stream.concat(itemToEdit.getPersons().stream(), addedPersons.stream()).toList();
+
+        return new Todo(
+                itemToEdit.getName(),
+                itemToEdit.getDeadline(),
+                itemToEdit.getLocation(),
+                combinedPersons
+        );
+    }
+
+    @Override
+    public String getInvalidIndexMessage() {
+        return MESSAGE_INVALID_TODO_DISPLAYED_INDEX;
+    }
+
+    @Override
+    public String getDuplicateMessage() {
+        return MESSAGE_DUPLICATE_TODO;
+    }
+
+    @Override
+    public String getSuccessMessage(Todo editedItem) {
+        return String.format(MESSAGE_ADD_PERSON_SUCCESS, Messages.format(editedItem));
+    }
+}

--- a/src/main/java/seedu/address/logic/commands/todo/RemovePersonFromTodoCommand.java
+++ b/src/main/java/seedu/address/logic/commands/todo/RemovePersonFromTodoCommand.java
@@ -1,0 +1,91 @@
+package seedu.address.logic.commands.todo;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.parser.CliSyntax.TODO_COMMAND_WORD;
+import static seedu.address.logic.parser.todo.TodoCliSyntax.PREFIX_LINKED_PERSON_INDEX;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.Messages;
+import seedu.address.logic.abstractcommand.EditCommand;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.person.Person;
+import seedu.address.model.todo.Todo;
+
+/**
+ * Remove some associated persons from a todo.
+ */
+public class RemovePersonFromTodoCommand extends EditCommand<Todo> {
+
+    public static final String COMMAND_WORD = "unlink";
+
+    public static final String MESSAGE_USAGE = TODO_COMMAND_WORD + " " + COMMAND_WORD
+            + ": Remove the association between a todo and some contacts.\n"
+            + "Parameters: INDEX"
+            + PREFIX_LINKED_PERSON_INDEX + "[PERSON_INDEX]...\n"
+            + "Example: " + TODO_COMMAND_WORD + " " + COMMAND_WORD + " 1 "
+            + PREFIX_LINKED_PERSON_INDEX + " 1 3 4";
+
+    public static final String MESSAGE_INVALID_PERSON_DISPLAYED_INDEX =
+            "The person index provided is invalid: %1$s";
+    public static final String MESSAGE_INVALID_TODO_DISPLAYED_INDEX =
+            "The todo index provided is invalid";
+    public static final String MESSAGE_REMOVE_PERSON_SUCCESS = "Removed persons from todo: %1$s";
+    public static final String MESSAGE_NOT_REMOVED = "At least one person must be provided.";
+    public static final String MESSAGE_DUPLICATE_TODO = "This todo already exists";
+
+    private final List<Index> personIndices;
+
+    /**
+     * Creates an RemovePersonFromTodoCommand to remove the persons at the specified {@code
+     * personIndices} from the list of persons in the todo at the specified {@code index}.
+     */
+    public RemovePersonFromTodoCommand(Index index, List<Index> personIndices) {
+        super(index, Model::getTodoManagerAndList);
+        requireNonNull(personIndices);
+        this.personIndices = personIndices;
+    }
+
+    @Override
+    public Todo createEditedItem(Model model, Todo todoToEdit) throws CommandException {
+        for (Index index : personIndices) {
+            if (index.getZeroBased() >= todoToEdit.getPersons().size()) {
+                System.out.println();
+                throw new CommandException(String.format(MESSAGE_INVALID_PERSON_DISPLAYED_INDEX,
+                        index.getOneBased()));
+            }
+        }
+
+        List<Person> newPersons = new ArrayList<>(todoToEdit.getPersons());
+        personIndices.stream()
+                .map(Index::getZeroBased)
+                .sorted(Comparator.reverseOrder())
+                .forEach(index -> newPersons.remove((int) index));
+
+        return new Todo(
+                todoToEdit.getName(),
+                todoToEdit.getDeadline(),
+                todoToEdit.getLocation(),
+                newPersons.stream().toList()
+        );
+    }
+
+    @Override
+    public String getInvalidIndexMessage() {
+        return MESSAGE_INVALID_TODO_DISPLAYED_INDEX;
+    }
+
+    @Override
+    public String getDuplicateMessage() {
+        return MESSAGE_DUPLICATE_TODO;
+    }
+
+    @Override
+    public String getSuccessMessage(Todo editedItem) {
+        return String.format(MESSAGE_REMOVE_PERSON_SUCCESS, Messages.format(editedItem));
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -2,8 +2,10 @@ package seedu.address.logic.parser;
 
 import static java.util.Objects.requireNonNull;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
 import seedu.address.commons.core.index.Index;
@@ -23,6 +25,7 @@ import seedu.address.model.person.Tag;
 public class ParserUtil {
 
     public static final String MESSAGE_INVALID_INDEX = "Index is not a non-zero unsigned integer.";
+    public static final String MESSAGE_DUPLICATE_INDEX = "Duplicate index found: %1$s";
 
     /**
      * Parses {@code oneBasedIndex} into an {@code Index} and returns it. Leading and trailing whitespaces will be
@@ -35,6 +38,39 @@ public class ParserUtil {
             throw new ParseException(MESSAGE_INVALID_INDEX);
         }
         return Index.fromOneBased(Integer.parseInt(trimmedIndex));
+    }
+
+    /**
+     * Parses {@code oneBasedIndices} into a {@code List<Index>} and returns it.
+     * Leading and trailing whitespaces will be trimmed.
+     * @throws ParseException if any specified index is invalid (not a non-zero unsigned integer)
+     * or if there are duplicate indices.
+     */
+    public static List<Index> parseIndices(String oneBasedIndices) throws ParseException {
+        String trimmedIndices = oneBasedIndices.trim();
+        if (trimmedIndices.isEmpty()) {
+            throw new ParseException(MESSAGE_INVALID_INDEX);
+        }
+
+        List<Index> indexList = new ArrayList<>();
+        Set<Index> seenIndices = new HashSet<>();
+
+        for (String strIndex : trimmedIndices.split("\\s+")) {
+            if (!StringUtil.isNonZeroUnsignedInteger(strIndex)) {
+                throw new ParseException(MESSAGE_INVALID_INDEX);
+            }
+
+            Index index = Index.fromOneBased(Integer.parseInt(strIndex));
+            if (seenIndices.contains(index)) {
+                throw new ParseException(String.format(MESSAGE_DUPLICATE_INDEX,
+                        index.getOneBased()));
+            }
+
+            seenIndices.add(index);
+            indexList.add(index);
+        }
+
+        return indexList.stream().toList();
     }
 
     /**

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -28,8 +28,9 @@ public class ParserUtil {
     public static final String MESSAGE_DUPLICATE_INDEX = "Duplicate index found: %1$s";
 
     /**
-     * Parses {@code oneBasedIndex} into an {@code Index} and returns it. Leading and trailing whitespaces will be
-     * trimmed.
+     * Parses {@code oneBasedIndex} into an {@code Index} and returns it. Leading and trailing
+     * whitespaces will be trimmed.
+     *
      * @throws ParseException if the specified index is invalid (not non-zero unsigned integer).
      */
     public static Index parseIndex(String oneBasedIndex) throws ParseException {
@@ -41,10 +42,11 @@ public class ParserUtil {
     }
 
     /**
-     * Parses {@code oneBasedIndices} into a {@code List<Index>} and returns it.
-     * Leading and trailing whitespaces will be trimmed.
-     * @throws ParseException if any specified index is invalid (not a non-zero unsigned integer)
-     * or if there are duplicate indices.
+     * Parses {@code oneBasedIndices} into a {@code List<Index>} and returns it. Leading and
+     * trailing whitespaces will be trimmed.
+     *
+     * @throws ParseException if any specified index is invalid (not a non-zero unsigned integer) or
+     *                        if there are duplicate indices.
      */
     public static List<Index> parseIndices(String oneBasedIndices) throws ParseException {
         String trimmedIndices = oneBasedIndices.trim();
@@ -74,8 +76,8 @@ public class ParserUtil {
     }
 
     /**
-     * Parses a {@code String id} into an {@code Id}.
-     * Leading and trailing whitespaces will be trimmed.
+     * Parses a {@code String id} into an {@code Id}. Leading and trailing whitespaces will be
+     * trimmed.
      *
      * @throws ParseException if the given {@code id} is invalid.
      */
@@ -89,8 +91,8 @@ public class ParserUtil {
     }
 
     /**
-     * Parses a {@code String name} into a {@code Name}.
-     * Leading and trailing whitespaces will be trimmed.
+     * Parses a {@code String name} into a {@code Name}. Leading and trailing whitespaces will be
+     * trimmed.
      *
      * @throws ParseException if the given {@code name} is invalid.
      */
@@ -104,8 +106,8 @@ public class ParserUtil {
     }
 
     /**
-     * Parses a {@code String phone} into a {@code Phone}.
-     * Leading and trailing whitespaces will be trimmed.
+     * Parses a {@code String phone} into a {@code Phone}. Leading and trailing whitespaces will be
+     * trimmed.
      *
      * @throws ParseException if the given {@code phone} is invalid.
      */
@@ -119,8 +121,8 @@ public class ParserUtil {
     }
 
     /**
-     * Parses a {@code String email} into an {@code Email}.
-     * Leading and trailing whitespaces will be trimmed.
+     * Parses a {@code String email} into an {@code Email}. Leading and trailing whitespaces will be
+     * trimmed.
      *
      * @throws ParseException if the given {@code email} is invalid.
      */
@@ -134,8 +136,8 @@ public class ParserUtil {
     }
 
     /**
-     * Parses a {@code String module} into a {@code Course}.
-     * Leading and trailing whitespaces will be trimmed.
+     * Parses a {@code String module} into a {@code Course}. Leading and trailing whitespaces will
+     * be trimmed.
      *
      * @throws ParseException if the given {@code module} is invalid.
      */
@@ -149,8 +151,8 @@ public class ParserUtil {
     }
 
     /**
-     * Parses a {@code String group} into a {@code Group}.
-     * Leading and trailing whitespaces will be trimmed.
+     * Parses a {@code String group} into a {@code Group}. Leading and trailing whitespaces will be
+     * trimmed.
      *
      * @throws ParseException if the given {@code group} is invalid.
      */
@@ -164,8 +166,8 @@ public class ParserUtil {
     }
 
     /**
-     * Parses a {@code String tag} into a {@code Tag}.
-     * Leading and trailing whitespaces will be trimmed.
+     * Parses a {@code String tag} into a {@code Tag}. Leading and trailing whitespaces will be
+     * trimmed.
      *
      * @throws ParseException if the given {@code tag} is invalid.
      */

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -28,8 +28,8 @@ public class ParserUtil {
     public static final String MESSAGE_DUPLICATE_INDEX = "Duplicate index found: %1$s";
 
     /**
-     * Parses {@code oneBasedIndex} into an {@code Index} and returns it. Leading and trailing
-     * whitespaces will be trimmed.
+     * Parses {@code oneBasedIndex} into an {@code Index} and returns it.
+     * Leading and trailing whitespaces will be trimmed.
      *
      * @throws ParseException if the specified index is invalid (not non-zero unsigned integer).
      */
@@ -42,8 +42,8 @@ public class ParserUtil {
     }
 
     /**
-     * Parses {@code oneBasedIndices} into a {@code List<Index>} and returns it. Leading and
-     * trailing whitespaces will be trimmed.
+     * Parses {@code oneBasedIndices} into a {@code List<Index>} and returns it.
+     * Leading and trailing whitespaces will be trimmed.
      *
      * @throws ParseException if any specified index is invalid (not a non-zero unsigned integer) or
      *                        if there are duplicate indices.
@@ -76,8 +76,8 @@ public class ParserUtil {
     }
 
     /**
-     * Parses a {@code String id} into an {@code Id}. Leading and trailing whitespaces will be
-     * trimmed.
+     * Parses a {@code String id} into an {@code Id}.
+     * Leading and trailing whitespaces will be trimmed.
      *
      * @throws ParseException if the given {@code id} is invalid.
      */
@@ -91,8 +91,8 @@ public class ParserUtil {
     }
 
     /**
-     * Parses a {@code String name} into a {@code Name}. Leading and trailing whitespaces will be
-     * trimmed.
+     * Parses a {@code String name} into a {@code Name}.
+     * Leading and trailing whitespaces will be trimmed.
      *
      * @throws ParseException if the given {@code name} is invalid.
      */
@@ -106,8 +106,8 @@ public class ParserUtil {
     }
 
     /**
-     * Parses a {@code String phone} into a {@code Phone}. Leading and trailing whitespaces will be
-     * trimmed.
+     * Parses a {@code String phone} into a {@code Phone}.
+     * Leading and trailing whitespaces will be trimmed.
      *
      * @throws ParseException if the given {@code phone} is invalid.
      */
@@ -121,8 +121,8 @@ public class ParserUtil {
     }
 
     /**
-     * Parses a {@code String email} into an {@code Email}. Leading and trailing whitespaces will be
-     * trimmed.
+     * Parses a {@code String email} into an {@code Email}.
+     * Leading and trailing whitespaces will be trimmed.
      *
      * @throws ParseException if the given {@code email} is invalid.
      */
@@ -136,8 +136,8 @@ public class ParserUtil {
     }
 
     /**
-     * Parses a {@code String module} into a {@code Course}. Leading and trailing whitespaces will
-     * be trimmed.
+     * Parses a {@code String module} into a {@code Course}.
+     * Leading and trailing whitespaces will be trimmed.
      *
      * @throws ParseException if the given {@code module} is invalid.
      */
@@ -151,8 +151,8 @@ public class ParserUtil {
     }
 
     /**
-     * Parses a {@code String group} into a {@code Group}. Leading and trailing whitespaces will be
-     * trimmed.
+     * Parses a {@code String group} into a {@code Group}.
+     * Leading and trailing whitespaces will be trimmed.
      *
      * @throws ParseException if the given {@code group} is invalid.
      */
@@ -166,8 +166,8 @@ public class ParserUtil {
     }
 
     /**
-     * Parses a {@code String tag} into a {@code Tag}. Leading and trailing whitespaces will be
-     * trimmed.
+     * Parses a {@code String tag} into a {@code Tag}.
+     * Leading and trailing whitespaces will be trimmed.
      *
      * @throws ParseException if the given {@code tag} is invalid.
      */

--- a/src/main/java/seedu/address/logic/parser/event/EventParser.java
+++ b/src/main/java/seedu/address/logic/parser/event/EventParser.java
@@ -11,9 +11,9 @@ import seedu.address.commons.core.LogsCenter;
 import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.event.AddEventCommand;
+import seedu.address.logic.commands.event.DeleteEventCommand;
 import seedu.address.logic.commands.event.DisplayEventInformationCommand;
 import seedu.address.logic.commands.event.ListEventCommand;
-import seedu.address.logic.commands.event.DeleteEventCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 
 /**
@@ -26,6 +26,7 @@ public class EventParser {
     private static final Pattern BASIC_COMMAND_FORMAT =
             Pattern.compile("(?<commandWord>\\S+)(?<arguments>.*)");
     private static final Logger logger = LogsCenter.getLogger(EventParser.class);
+
     /**
      * Parses user input into command for execution.
      *

--- a/src/main/java/seedu/address/logic/parser/todo/AddPersonToTodoCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/todo/AddPersonToTodoCommandParser.java
@@ -1,0 +1,53 @@
+package seedu.address.logic.parser.todo;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.todo.TodoCliSyntax.PREFIX_LINKED_PERSON_INDEX;
+
+import java.util.List;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.todo.AddPersonToTodoCommand;
+import seedu.address.logic.parser.ArgumentMultimap;
+import seedu.address.logic.parser.ArgumentTokenizer;
+import seedu.address.logic.parser.Parser;
+import seedu.address.logic.parser.ParserUtil;
+import seedu.address.logic.parser.exceptions.ParseException;
+
+/**
+ * Parses input arguments and creates a new AddPersonToTodoCommandParser object
+ */
+public class AddPersonToTodoCommandParser implements Parser<AddPersonToTodoCommand> {
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the
+     * AddPersonToTodoCommandParser and returns a AddPersonToTodoCommandParser object for
+     * execution.
+     *
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public AddPersonToTodoCommand parse(String args) throws ParseException {
+        requireNonNull(args);
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_LINKED_PERSON_INDEX);
+
+        Index index;
+
+        try {
+            index = ParserUtil.parseIndex(argMultimap.getPreamble());
+        } catch (ParseException pe) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                    AddPersonToTodoCommand.MESSAGE_USAGE), pe);
+        }
+
+        argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_LINKED_PERSON_INDEX);
+        List<Index> personIndices =
+                ParserUtil.parseIndices(argMultimap.getValue(PREFIX_LINKED_PERSON_INDEX).get());
+
+        if (personIndices.isEmpty()) {
+            throw new ParseException(AddPersonToTodoCommand.MESSAGE_NOT_ADDED);
+        }
+
+        return new AddPersonToTodoCommand(index, personIndices);
+    }
+
+}

--- a/src/main/java/seedu/address/logic/parser/todo/RemovePersonFromTodoCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/todo/RemovePersonFromTodoCommandParser.java
@@ -1,0 +1,53 @@
+package seedu.address.logic.parser.todo;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.todo.TodoCliSyntax.PREFIX_LINKED_PERSON_INDEX;
+
+import java.util.List;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.todo.RemovePersonFromTodoCommand;
+import seedu.address.logic.parser.ArgumentMultimap;
+import seedu.address.logic.parser.ArgumentTokenizer;
+import seedu.address.logic.parser.Parser;
+import seedu.address.logic.parser.ParserUtil;
+import seedu.address.logic.parser.exceptions.ParseException;
+
+/**
+ * Parses input arguments and creates a new RemovePersonFromTodoCommandParser object
+ */
+public class RemovePersonFromTodoCommandParser implements Parser<RemovePersonFromTodoCommand> {
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the
+     * RemovePersonFromTodoCommandParser and returns a RemovePersonFromTodoCommandParser object for
+     * execution.
+     *
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public RemovePersonFromTodoCommand parse(String args) throws ParseException {
+        requireNonNull(args);
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_LINKED_PERSON_INDEX);
+
+        Index index;
+
+        try {
+            index = ParserUtil.parseIndex(argMultimap.getPreamble());
+        } catch (ParseException pe) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                    RemovePersonFromTodoCommand.MESSAGE_USAGE), pe);
+        }
+
+        argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_LINKED_PERSON_INDEX);
+        List<Index> personIndices =
+                ParserUtil.parseIndices(argMultimap.getValue(PREFIX_LINKED_PERSON_INDEX).get());
+
+        if (personIndices.isEmpty()) {
+            throw new ParseException(RemovePersonFromTodoCommand.MESSAGE_NOT_REMOVED);
+        }
+
+        return new RemovePersonFromTodoCommand(index, personIndices);
+    }
+
+}

--- a/src/main/java/seedu/address/logic/parser/todo/TodoCliSyntax.java
+++ b/src/main/java/seedu/address/logic/parser/todo/TodoCliSyntax.java
@@ -11,5 +11,6 @@ public class TodoCliSyntax {
     public static final Prefix PREFIX_TODO_NAME = new Prefix("n/");
     public static final Prefix PREFIX_TODO_DEADLINE = new Prefix("d/");
     public static final Prefix PREFIX_TODO_LOCATION = new Prefix("l/");
+    public static final Prefix PREFIX_LINKED_PERSON_INDEX = new Prefix("p/");
 
 }

--- a/src/main/java/seedu/address/logic/parser/todo/TodoParser.java
+++ b/src/main/java/seedu/address/logic/parser/todo/TodoParser.java
@@ -15,6 +15,7 @@ import seedu.address.logic.commands.todo.AddTodoCommand;
 import seedu.address.logic.commands.todo.DeleteTodoCommand;
 import seedu.address.logic.commands.todo.DisplayTodoInformationCommand;
 import seedu.address.logic.commands.todo.ListTodoCommand;
+import seedu.address.logic.commands.todo.RemovePersonFromTodoCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 
 /**
@@ -68,6 +69,9 @@ public class TodoParser {
 
         case AddPersonToTodoCommand.COMMAND_WORD:
             return new AddPersonToTodoCommandParser().parse(arguments);
+
+        case RemovePersonFromTodoCommand.COMMAND_WORD:
+            return new RemovePersonFromTodoCommandParser().parse(arguments);
 
         default:
             logger.finer("This user input caused a ParseException: " + userInput);

--- a/src/main/java/seedu/address/logic/parser/todo/TodoParser.java
+++ b/src/main/java/seedu/address/logic/parser/todo/TodoParser.java
@@ -10,6 +10,7 @@ import java.util.regex.Pattern;
 import seedu.address.commons.core.LogsCenter;
 import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.HelpCommand;
+import seedu.address.logic.commands.todo.AddPersonToTodoCommand;
 import seedu.address.logic.commands.todo.AddTodoCommand;
 import seedu.address.logic.commands.todo.DeleteTodoCommand;
 import seedu.address.logic.commands.todo.DisplayTodoInformationCommand;
@@ -64,6 +65,9 @@ public class TodoParser {
 
         case DeleteTodoCommand.COMMAND_WORD:
             return new DeleteTodoCommandParser().parse(arguments);
+
+        case AddPersonToTodoCommand.COMMAND_WORD:
+            return new AddPersonToTodoCommandParser().parse(arguments);
 
         default:
             logger.finer("This user input caused a ParseException: " + userInput);

--- a/src/main/java/seedu/address/model/todo/Todo.java
+++ b/src/main/java/seedu/address/model/todo/Todo.java
@@ -2,10 +2,12 @@ package seedu.address.model.todo;
 
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
+import java.util.List;
 import java.util.Objects;
 
 import seedu.address.commons.util.ToStringBuilder;
 import seedu.address.model.item.Item;
+import seedu.address.model.person.Person;
 
 /**
  * Represents a Todo.
@@ -19,6 +21,18 @@ public class Todo implements Item {
     // Data fields
     private final TodoDeadline deadline;
     private final TodoLocation location;
+    private final List<Person> persons;
+
+    /**
+     * Every field must be present and not null.
+     */
+    public Todo(TodoName name, TodoDeadline deadline, TodoLocation location, List<Person> persons) {
+        requireAllNonNull(name, deadline, location);
+        this.name = name;
+        this.deadline = deadline;
+        this.location = location;
+        this.persons = persons.stream().toList();
+    }
 
     /**
      * Every field must be present and not null.
@@ -28,6 +42,7 @@ public class Todo implements Item {
         this.name = name;
         this.deadline = deadline;
         this.location = location;
+        this.persons = List.of();
     }
 
     public TodoName getName() {
@@ -40,6 +55,10 @@ public class Todo implements Item {
 
     public TodoLocation getLocation() {
         return location;
+    }
+
+    public List<Person> getPersons() {
+        return persons;
     }
 
     /**
@@ -59,13 +78,14 @@ public class Todo implements Item {
 
         return name.equals(otherTodo.name)
                 && deadline.equals(otherTodo.deadline)
-                && location.equals(otherTodo.location);
+                && location.equals(otherTodo.location)
+                && persons.equals(otherTodo.persons);
     }
 
     @Override
     public int hashCode() {
         // use this method for custom fields hashing instead of implementing your own
-        return Objects.hash(name, deadline, location);
+        return Objects.hash(name, deadline, location, persons);
     }
 
     @Override
@@ -74,6 +94,7 @@ public class Todo implements Item {
                 .add("name", name)
                 .add("deadline", deadline)
                 .add("location", location)
+                .add("persons", persons)
                 .toString();
     }
 }


### PR DESCRIPTION
Add contacts command: `todo link <todo_index> p/[<person_index_1> <person_index_2> ...]`. Person indices are based on the displayed list.

Example: `todo link 1 p/1 2 3`

Remove contacts command: `todo unlink <todo_index> p/[<person_index_1> <person_index_2> ...]`.  Person indices are based on the contact's internal list displayed by the `info` command.

Example: `todo unlink 1 p/1 2 3`

Resolves #94
Resolves #95