### PR TITLE
[#104] linking and logging for contacts in event

### DIFF
--- a/src/main/java/seedu/address/logic/EventMessages.java
+++ b/src/main/java/seedu/address/logic/EventMessages.java
@@ -1,0 +1,15 @@
+package seedu.address.logic;
+
+/**
+ * Container for user visible messages related to events.
+ */
+public class EventMessages {
+    public static final String MESSAGE_INVALID_PERSON_DISPLAYED_INDEX =
+            "The person index provided is invalid: %1$s";
+    public static final String MESSAGE_INVALID_EVENT_DISPLAYED_INDEX =
+            "The event index provided is invalid";
+    public static final String MESSAGE_DUPLICATE_EVENT =
+            "This event already exists";
+    public static final String MESSAGE_NOT_REMOVED =
+            "At least one person must be provided.";
+}

--- a/src/main/java/seedu/address/logic/Messages.java
+++ b/src/main/java/seedu/address/logic/Messages.java
@@ -81,19 +81,14 @@ public class Messages {
      * Formats the {@code todo} for display to the user.
      */
     public static String format(Event event) {
-        String personListFormatted;
-        if (event.getPersons().isEmpty()) {
-            personListFormatted = "None";
-        } else {
-            personListFormatted = "\n" + IntStream.range(0, event.getPersons().size())
-                    .mapToObj(i -> String.format("%d. %s", i + 1, getSimplifiedFormat(event.getPersons().get(i))))
-                    .collect(Collectors.joining("\n"));
-        }
+        String personListFormatted = getEventPersonListFormatted(event);
+        String markedPersonListFormated = getEventMarkedPersonListFormatted(event);
         return event.getName()
                 + "; Start Time: " + event.getStartTime()
                 + "; End Time: " + event.getEndTime()
                 + "; Location: " + event.getLocation()
-                + "; personListFormatted" + personListFormatted;
+                + "; Persons: " + personListFormatted
+                + "; Marked Persons:  " + markedPersonListFormated;
     }
 
     /**
@@ -104,5 +99,32 @@ public class Messages {
                 + "; ID: " + person.getId()
                 + "; Course: " + person.getCourse()
                 + "; Group: " + person.getGroup();
+    }
+
+    private static String getEventPersonListFormatted(Event event) {
+        String string;
+        if (event.getPersons().isEmpty()) {
+            string = "None";
+        } else {
+            string = "\n" + IntStream.range(0, event.getPersons().size())
+                    .mapToObj(i -> String.format("%d. %s", i + 1, getSimplifiedFormat(event.getPersons().get(i))))
+                    .collect(Collectors.joining("\n"));
+        }
+        return string;
+    }
+
+    private static String getEventMarkedPersonListFormatted(Event event) {
+        String string;
+        if (event.getMarkedList().isEmpty()) {
+            string = "None";
+        } else {
+            string = IntStream.range(0, event.getPersons().size())
+                    .mapToObj(x -> String.format(
+                            "%d.[%s] %s", x + 1,
+                            event.getMarkedList().get(x) ? "X" : " ",
+                            event.getPersons().get(x)))
+                    .collect(Collectors.joining("\n"));
+        }
+        return string;
     }
 }

--- a/src/main/java/seedu/address/logic/Messages.java
+++ b/src/main/java/seedu/address/logic/Messages.java
@@ -82,13 +82,11 @@ public class Messages {
      */
     public static String format(Event event) {
         String personListFormatted = getEventPersonListFormatted(event);
-        String markedPersonListFormated = getEventMarkedPersonListFormatted(event);
         return event.getName()
                 + "; Start Time: " + event.getStartTime()
                 + "; End Time: " + event.getEndTime()
                 + "; Location: " + event.getLocation()
-                + "; Persons: " + personListFormatted
-                + "; Marked Persons:  " + markedPersonListFormated;
+                + "; Persons: " + personListFormatted;
     }
 
     /**
@@ -102,29 +100,14 @@ public class Messages {
     }
 
     private static String getEventPersonListFormatted(Event event) {
-        String string;
         if (event.getPersons().isEmpty()) {
-            string = "None";
-        } else {
-            string = "\n" + IntStream.range(0, event.getPersons().size())
-                    .mapToObj(i -> String.format("%d. %s", i + 1, getSimplifiedFormat(event.getPersons().get(i))))
-                    .collect(Collectors.joining("\n"));
-        }
-        return string;
-    }
-
-    private static String getEventMarkedPersonListFormatted(Event event) {
-        String string;
-        if (event.getMarkedList().isEmpty()) {
-            string = "None";
-        } else {
-            string = IntStream.range(0, event.getPersons().size())
-                    .mapToObj(x -> String.format(
-                            "%d.[%s] %s", x + 1,
-                            event.getMarkedList().get(x) ? "X" : " ",
-                            event.getPersons().get(x)))
-                    .collect(Collectors.joining("\n"));
-        }
+            return "None";
+        } 
+        String string = "\n" + IntStream.range(0, event.getPersons().size())
+                .mapToObj(i -> String.format("%d.[%s] %s",
+                        i + 1, event.getMarkedList().get(i) ? "X" : " ",
+                        getSimplifiedFormat(event.getPersons().get(i))))
+                .collect(Collectors.joining("\n"));
         return string;
     }
 }

--- a/src/main/java/seedu/address/logic/Messages.java
+++ b/src/main/java/seedu/address/logic/Messages.java
@@ -102,7 +102,7 @@ public class Messages {
     private static String getEventPersonListFormatted(Event event) {
         if (event.getPersons().isEmpty()) {
             return "None";
-        } 
+        }
         String string = "\n" + IntStream.range(0, event.getPersons().size())
                 .mapToObj(i -> String.format("%d.[%s] %s",
                         i + 1, event.getMarkedList().get(i) ? "X" : " ",

--- a/src/main/java/seedu/address/logic/Messages.java
+++ b/src/main/java/seedu/address/logic/Messages.java
@@ -81,10 +81,19 @@ public class Messages {
      * Formats the {@code todo} for display to the user.
      */
     public static String format(Event event) {
+        String personListFormatted;
+        if (event.getPersons().isEmpty()) {
+            personListFormatted = "None";
+        } else {
+            personListFormatted = "\n" + IntStream.range(0, event.getPersons().size())
+                    .mapToObj(i -> String.format("%d. %s", i + 1, getSimplifiedFormat(event.getPersons().get(i))))
+                    .collect(Collectors.joining("\n"));
+        }
         return event.getName()
                 + "; Start Time: " + event.getStartTime()
                 + "; End Time: " + event.getEndTime()
-                + "; Location: " + event.getLocation();
+                + "; Location: " + event.getLocation()
+                + "; personListFormatted" + personListFormatted;
     }
 
     /**

--- a/src/main/java/seedu/address/logic/commands/event/AddPersonToEventCommand.java
+++ b/src/main/java/seedu/address/logic/commands/event/AddPersonToEventCommand.java
@@ -72,12 +72,18 @@ public class AddPersonToEventCommand extends EditCommand<Event> {
         List<Person> combinedPersonList = Stream
                 .concat(itemToEdit.getPersons().stream(), addedPersons.stream())
                 .toList();
+        // To add a mapping of newly added persons to a new position in markedList
+        List<Boolean> combinedMarkedList = Stream
+                .concat(itemToEdit.getMarkedList().stream(), addedPersons.stream().map(x -> false))
+                .toList();
         return new Event(
                 itemToEdit.getName(),
                 itemToEdit.getStartTime(),
                 itemToEdit.getEndTime(),
                 itemToEdit.getLocation(),
-                combinedPersonList);
+                combinedPersonList,
+                combinedMarkedList
+        );
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/event/AddPersonToEventCommand.java
+++ b/src/main/java/seedu/address/logic/commands/event/AddPersonToEventCommand.java
@@ -9,6 +9,7 @@ import java.util.function.Function;
 import java.util.stream.Stream;
 
 import seedu.address.commons.core.index.Index;
+import seedu.address.logic.EventMessages;
 import seedu.address.logic.Messages;
 import seedu.address.logic.abstractcommand.EditCommand;
 import seedu.address.logic.commands.exceptions.CommandException;
@@ -28,13 +29,8 @@ public class AddPersonToEventCommand extends EditCommand<Event> {
             + PREFIX_LINKED_PERSON_INDEX + " [PERSON_INDEX]...\n"
             + "Example: " + EVENT_COMMAND_WORD + " " + COMMAND_WORD + "1 "
             + PREFIX_LINKED_PERSON_INDEX + " 1 3 4";
-
-    public static final String MESSAGE_INVALID_PERSON_DISPLAYED_INDEX = "The person index provided is invalid: %1$s";
-    public static final String MESSAGE_INVALID_EVENT_DISPLAYED_INDEX = "The event index provided is invalid";
     public static final String MESSAGE_ADD_PERSON_SUCCESS = "Added persons to event: %1$s";
-    public static final String MESSAGE_NOT_ADDED = "At least one person must be provided.";
     public static final String MESSAGE_DUPLICATE_PERSON = "Person %1$s is already assigned to this event.";
-    public static final String MESSAGE_DUPLICATE_EVENT = "This event already exists";
 
     private final List<Index> personIndices;
     private final Function<Model, ItemManagerWithFilteredList<Person>> personManagerAndListGetter =
@@ -55,7 +51,7 @@ public class AddPersonToEventCommand extends EditCommand<Event> {
         List<Person> filteredPersons = personManagerAndListGetter.apply(model).getFilteredItemsList();
         for (Index index : this.personIndices) {
             if (index.getZeroBased() >= filteredPersons.size()) {
-                throw new CommandException(String.format(MESSAGE_INVALID_PERSON_DISPLAYED_INDEX,
+                throw new CommandException(String.format(EventMessages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX,
                         index.getOneBased()));
             }
         }
@@ -88,12 +84,12 @@ public class AddPersonToEventCommand extends EditCommand<Event> {
 
     @Override
     public String getInvalidIndexMessage() {
-        return MESSAGE_INVALID_EVENT_DISPLAYED_INDEX;
+        return EventMessages.MESSAGE_INVALID_EVENT_DISPLAYED_INDEX;
     }
 
     @Override
     public String getDuplicateMessage() {
-        return MESSAGE_DUPLICATE_EVENT;
+        return EventMessages.MESSAGE_DUPLICATE_EVENT;
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/event/AddPersonToEventCommand.java
+++ b/src/main/java/seedu/address/logic/commands/event/AddPersonToEventCommand.java
@@ -1,0 +1,97 @@
+package seedu.address.logic.commands.event;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.parser.CliSyntax.EVENT_COMMAND_WORD;
+import static seedu.address.logic.parser.event.EventCliSyntax.PREFIX_LINKED_PERSON_INDEX;
+
+import java.util.List;
+import java.util.function.Function;
+import java.util.stream.Stream;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.Messages;
+import seedu.address.logic.abstractcommand.EditCommand;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.event.Event;
+import seedu.address.model.item.ItemManagerWithFilteredList;
+import seedu.address.model.person.Person;
+
+/**
+ * Associates a list of people to an event.
+ */
+public class AddPersonToEventCommand extends EditCommand<Event> {
+    public static final String COMMAND_WORD = "link";
+    public static final String MESSAGE_USAGE = EVENT_COMMAND_WORD + " " + COMMAND_WORD
+            + ": Associate an event with some contacts.\n"
+            + "Parameters: INDEX "
+            + PREFIX_LINKED_PERSON_INDEX + " [PERSON_INDEX]...\n"
+            + "Example: " + EVENT_COMMAND_WORD + " " + COMMAND_WORD + "1 "
+            + PREFIX_LINKED_PERSON_INDEX + " 1 3 4";
+
+    public static final String MESSAGE_INVALID_PERSON_DISPLAYED_INDEX = "The person index provided is invalid: %1$s";
+    public static final String MESSAGE_INVALID_EVENT_DISPLAYED_INDEX = "The event index provided is invalid";
+    public static final String MESSAGE_ADD_PERSON_SUCCESS = "Added persons to event: %1$s";
+    public static final String MESSAGE_NOT_ADDED = "At least one person must be provided.";
+    public static final String MESSAGE_DUPLICATE_PERSON = "Person %1$s is already assigned to this event.";
+    public static final String MESSAGE_DUPLICATE_EVENT = "This event already exists";
+
+    private final List<Index> personIndices;
+    private final Function<Model, ItemManagerWithFilteredList<Person>> personManagerAndListGetter =
+            Model::getPersonManagerAndList;
+
+    /**
+     * Creates an AddPersonToEventCommand to add the persons at the specified {@code personIndices}
+     * to the event at the specified {@code index}.
+     */
+    public AddPersonToEventCommand(Index index, List<Index> personIndices) {
+        super(index, Model::getEventManagerAndList);
+        requireNonNull(personIndices);
+        this.personIndices = personIndices;
+    }
+
+    @Override
+    public Event createEditedItem(Model model, Event itemToEdit) throws CommandException {
+        List<Person> filteredPersons = personManagerAndListGetter.apply(model).getFilteredItemsList();
+        for (Index index : this.personIndices) {
+            if (index.getZeroBased() >= filteredPersons.size()) {
+                throw new CommandException(String.format(MESSAGE_INVALID_PERSON_DISPLAYED_INDEX,
+                        index.getOneBased()));
+            }
+        }
+        // Getting people from the model to check for duplicates
+        List<Person> addedPersons = personIndices.stream()
+                .map(index -> filteredPersons.get(index.getZeroBased()))
+                .toList();
+        for (Person person : addedPersons) {
+            if (itemToEdit.getPersons().contains(person)) {
+                throw new CommandException(String.format(MESSAGE_DUPLICATE_PERSON,
+                        Messages.getSimplifiedFormat(person)));
+            }
+        }
+        List<Person> combinedPersonList = Stream
+                .concat(itemToEdit.getPersons().stream(), addedPersons.stream())
+                .toList();
+        return new Event(
+                itemToEdit.getName(),
+                itemToEdit.getStartTime(),
+                itemToEdit.getEndTime(),
+                itemToEdit.getLocation(),
+                combinedPersonList);
+    }
+
+    @Override
+    public String getInvalidIndexMessage() {
+        return MESSAGE_INVALID_EVENT_DISPLAYED_INDEX;
+    }
+
+    @Override
+    public String getDuplicateMessage() {
+        return MESSAGE_DUPLICATE_EVENT;
+    }
+
+    @Override
+    public String getSuccessMessage(Event editedItem) {
+        return String.format(MESSAGE_ADD_PERSON_SUCCESS, Messages.format(editedItem));
+    }
+}

--- a/src/main/java/seedu/address/logic/commands/event/AddPersonToLogEventCommand.java
+++ b/src/main/java/seedu/address/logic/commands/event/AddPersonToLogEventCommand.java
@@ -31,7 +31,7 @@ public class AddPersonToLogEventCommand extends EditCommand<Event> {
             "The person index provided is invalid: %1$s";
     public static final String MESSAGE_INVALID_EVENT_DISPLAYED_INDEX =
             "The event index provided is invalid";
-    public static final String MESSAGE_ADD_LOG_SUCCESS = "Added attendence from persons from event: %1$s";
+    public static final String MESSAGE_ADD_LOG_SUCCESS = "Added attendence from persons to event: %1$s";
     public static final String MESSAGE_NOT_REMOVED = "At least one person must be provided.";
     public static final String MESSAGE_DUPLICATE_EVENT = "This event already exists";
 

--- a/src/main/java/seedu/address/logic/commands/event/AddPersonToLogEventCommand.java
+++ b/src/main/java/seedu/address/logic/commands/event/AddPersonToLogEventCommand.java
@@ -15,7 +15,10 @@ import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.event.Event;
 
-public class AddPersonToLogEventCommand extends EditCommand<Event>{
+/**
+ * Adds the log of given contacts via index.
+ */
+public class AddPersonToLogEventCommand extends EditCommand<Event> {
     public static final String COMMAND_WORD = "log";
 
     public static final String MESSAGE_USAGE = EVENT_COMMAND_WORD + " " + COMMAND_WORD
@@ -28,15 +31,15 @@ public class AddPersonToLogEventCommand extends EditCommand<Event>{
             "The person index provided is invalid: %1$s";
     public static final String MESSAGE_INVALID_EVENT_DISPLAYED_INDEX =
             "The event index provided is invalid";
-    public static final String MESSAGE_ADD_LOG_SUCCESS = "Removed attendence from persons from event: %1$s";
+    public static final String MESSAGE_ADD_LOG_SUCCESS = "Added attendence from persons from event: %1$s";
     public static final String MESSAGE_NOT_REMOVED = "At least one person must be provided.";
     public static final String MESSAGE_DUPLICATE_EVENT = "This event already exists";
 
     private final List<Index> personIndices;
 
     /**
-     * Creates a RemovePersonFromEventCommand to remove the persons at the specific {@code 
-     * personIndices}
+     * Creates a RemovePersonFromEventCommand to remove the persons at the specific {@code
+     * personIndices}.
      */
     public AddPersonToLogEventCommand(Index index, List<Index> personIndices) {
         super(index, Model::getEventManagerAndList);
@@ -56,7 +59,7 @@ public class AddPersonToLogEventCommand extends EditCommand<Event>{
         personIndices.stream()
                 .map(Index::getZeroBased)
                 .sorted(Comparator.reverseOrder())
-                .forEach(index -> newMarkList.add(index, true));
+                .forEach(index -> newMarkList.set(index, true));
         return new Event(
                 eventToEdit.getName(),
                 eventToEdit.getStartTime(),

--- a/src/main/java/seedu/address/logic/commands/event/AddPersonToLogEventCommand.java
+++ b/src/main/java/seedu/address/logic/commands/event/AddPersonToLogEventCommand.java
@@ -7,8 +7,10 @@ import static seedu.address.logic.parser.event.EventCliSyntax.PREFIX_LINKED_PERS
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import seedu.address.commons.core.index.Index;
+import seedu.address.logic.EventMessages;
 import seedu.address.logic.Messages;
 import seedu.address.logic.abstractcommand.EditCommand;
 import seedu.address.logic.commands.exceptions.CommandException;
@@ -27,13 +29,9 @@ public class AddPersonToLogEventCommand extends EditCommand<Event> {
             + PREFIX_LINKED_PERSON_INDEX + " [PERSON_INDEX]...\n"
             + "Example: " + EVENT_COMMAND_WORD + " " + COMMAND_WORD + " 1 "
             + PREFIX_LINKED_PERSON_INDEX + " 1 2 3";
-    public static final String MESSAGE_INVALID_PERSON_DISPLAYED_INDEX =
-            "The person index provided is invalid: %1$s";
-    public static final String MESSAGE_INVALID_EVENT_DISPLAYED_INDEX =
-            "The event index provided is invalid";
     public static final String MESSAGE_ADD_LOG_SUCCESS = "Added attendence from persons to event: %1$s";
-    public static final String MESSAGE_NOT_REMOVED = "At least one person must be provided.";
-    public static final String MESSAGE_DUPLICATE_EVENT = "This event already exists";
+    public static final String MESSAGE_PERSON_ALREADY_LOGGED =
+            "The person at the following index(es) are already logged: %s";
 
     private final List<Index> personIndices;
 
@@ -51,11 +49,21 @@ public class AddPersonToLogEventCommand extends EditCommand<Event> {
     public Event createEditedItem(Model model, Event eventToEdit) throws CommandException {
         for (Index index : personIndices) {
             if (index.getZeroBased() >= eventToEdit.getPersons().size()) {
-                throw new CommandException(String.format(MESSAGE_INVALID_PERSON_DISPLAYED_INDEX,
+                throw new CommandException(String.format(EventMessages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX,
                         index.getOneBased()));
             }
         }
         List<Boolean> newMarkList = new ArrayList<>(eventToEdit.getMarkedList());
+        List<Index> checkPersonMarked = personIndices.stream()
+                .filter(x -> newMarkList.get(x.getZeroBased()))
+                .toList();
+        if (!checkPersonMarked.isEmpty()) {
+            throw new CommandException(String.format(MESSAGE_PERSON_ALREADY_LOGGED,
+                    checkPersonMarked.stream()
+                            .map(x -> String.valueOf(x.getOneBased()))
+                            .collect(Collectors.joining(", ")))
+            );
+        }
         personIndices.stream()
                 .map(Index::getZeroBased)
                 .sorted(Comparator.reverseOrder())
@@ -71,12 +79,12 @@ public class AddPersonToLogEventCommand extends EditCommand<Event> {
 
     @Override
     public String getInvalidIndexMessage() {
-        return MESSAGE_INVALID_EVENT_DISPLAYED_INDEX;
+        return EventMessages.MESSAGE_INVALID_EVENT_DISPLAYED_INDEX;
     }
 
     @Override
     public String getDuplicateMessage() {
-        return MESSAGE_DUPLICATE_EVENT;
+        return EventMessages.MESSAGE_DUPLICATE_EVENT;
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/event/AddPersonToLogEventCommand.java
+++ b/src/main/java/seedu/address/logic/commands/event/AddPersonToLogEventCommand.java
@@ -14,36 +14,31 @@ import seedu.address.logic.abstractcommand.EditCommand;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.event.Event;
-import seedu.address.model.person.Person;
 
-/**
- * Remove some associated people from an event class
- */
-public class RemovePersonFromEventCommand extends EditCommand<Event> {
-    public static final String COMMAND_WORD = "unlink";
+public class AddPersonToLogEventCommand extends EditCommand<Event>{
+    public static final String COMMAND_WORD = "log";
 
     public static final String MESSAGE_USAGE = EVENT_COMMAND_WORD + " " + COMMAND_WORD
-            + ": Remove the association between a event and some contacts.\n"
+            + ": Logs some contacts with an event.\n"
             + "Parameters: INDEX "
             + PREFIX_LINKED_PERSON_INDEX + " [PERSON_INDEX]...\n"
             + "Example: " + EVENT_COMMAND_WORD + " " + COMMAND_WORD + " 1 "
-            + PREFIX_LINKED_PERSON_INDEX + " 1 3 4";
-
+            + PREFIX_LINKED_PERSON_INDEX + " 1 2 3";
     public static final String MESSAGE_INVALID_PERSON_DISPLAYED_INDEX =
             "The person index provided is invalid: %1$s";
     public static final String MESSAGE_INVALID_EVENT_DISPLAYED_INDEX =
             "The event index provided is invalid";
-    public static final String MESSAGE_REMOVE_PERSON_SUCCESS = "Removed persons from event: %1$s";
+    public static final String MESSAGE_ADD_LOG_SUCCESS = "Removed attendence from persons from event: %1$s";
     public static final String MESSAGE_NOT_REMOVED = "At least one person must be provided.";
     public static final String MESSAGE_DUPLICATE_EVENT = "This event already exists";
 
     private final List<Index> personIndices;
 
     /**
-     * Creates a RemovePersonFromEventCommand to remove the persons at the specified {@code
-     * personIndices} from the list of persons in the event at the specified {@code index}.
+     * Creates a RemovePersonFromEventCommand to remove the persons at the specific {@code 
+     * personIndices}
      */
-    public RemovePersonFromEventCommand(Index index, List<Index> personIndices) {
+    public AddPersonToLogEventCommand(Index index, List<Index> personIndices) {
         super(index, Model::getEventManagerAndList);
         requireNonNull(personIndices);
         this.personIndices = personIndices;
@@ -53,29 +48,22 @@ public class RemovePersonFromEventCommand extends EditCommand<Event> {
     public Event createEditedItem(Model model, Event eventToEdit) throws CommandException {
         for (Index index : personIndices) {
             if (index.getZeroBased() >= eventToEdit.getPersons().size()) {
-                // System.out.println();
                 throw new CommandException(String.format(MESSAGE_INVALID_PERSON_DISPLAYED_INDEX,
                         index.getOneBased()));
             }
         }
-        List<Person> newPersons = new ArrayList<>(eventToEdit.getPersons());
         List<Boolean> newMarkList = new ArrayList<>(eventToEdit.getMarkedList());
         personIndices.stream()
                 .map(Index::getZeroBased)
                 .sorted(Comparator.reverseOrder())
-                .forEach(index -> newPersons.remove((int) index));
-        personIndices.stream()
-                .map(Index::getZeroBased)
-                .sorted(Comparator.reverseOrder())
-                .forEach(index -> newMarkList.remove((int) index));
+                .forEach(index -> newMarkList.add(index, true));
         return new Event(
-            eventToEdit.getName(),
-            eventToEdit.getStartTime(),
-            eventToEdit.getEndTime(),
-            eventToEdit.getLocation(),
-            List.copyOf(newPersons),
-            List.copyOf(newMarkList)
-        );
+                eventToEdit.getName(),
+                eventToEdit.getStartTime(),
+                eventToEdit.getEndTime(),
+                eventToEdit.getLocation(),
+                eventToEdit.getPersons(),
+                List.copyOf(newMarkList));
     }
 
     @Override
@@ -90,6 +78,6 @@ public class RemovePersonFromEventCommand extends EditCommand<Event> {
 
     @Override
     public String getSuccessMessage(Event editedItem) {
-        return String.format(MESSAGE_REMOVE_PERSON_SUCCESS, Messages.format(editedItem));
+        return String.format(MESSAGE_ADD_LOG_SUCCESS, Messages.format(editedItem));
     }
 }

--- a/src/main/java/seedu/address/logic/commands/event/ListEventCommand.java
+++ b/src/main/java/seedu/address/logic/commands/event/ListEventCommand.java
@@ -5,7 +5,7 @@ import seedu.address.model.Model;
 import seedu.address.model.event.Event;
 
 /**
- * Lists all events to the user
+ * Lists all events to the user.
  */
 public class ListEventCommand extends ListCommand<Event> {
 

--- a/src/main/java/seedu/address/logic/commands/event/RemovePersonFromEventCommand.java
+++ b/src/main/java/seedu/address/logic/commands/event/RemovePersonFromEventCommand.java
@@ -9,6 +9,7 @@ import java.util.Comparator;
 import java.util.List;
 
 import seedu.address.commons.core.index.Index;
+import seedu.address.logic.EventMessages;
 import seedu.address.logic.Messages;
 import seedu.address.logic.abstractcommand.EditCommand;
 import seedu.address.logic.commands.exceptions.CommandException;
@@ -28,14 +29,7 @@ public class RemovePersonFromEventCommand extends EditCommand<Event> {
             + PREFIX_LINKED_PERSON_INDEX + " [PERSON_INDEX]...\n"
             + "Example: " + EVENT_COMMAND_WORD + " " + COMMAND_WORD + " 1 "
             + PREFIX_LINKED_PERSON_INDEX + " 1 3 4";
-
-    public static final String MESSAGE_INVALID_PERSON_DISPLAYED_INDEX =
-            "The person index provided is invalid: %1$s";
-    public static final String MESSAGE_INVALID_EVENT_DISPLAYED_INDEX =
-            "The event index provided is invalid";
     public static final String MESSAGE_REMOVE_PERSON_SUCCESS = "Removed persons from event: %1$s";
-    public static final String MESSAGE_NOT_REMOVED = "At least one person must be provided.";
-    public static final String MESSAGE_DUPLICATE_EVENT = "This event already exists";
 
     private final List<Index> personIndices;
 
@@ -54,7 +48,7 @@ public class RemovePersonFromEventCommand extends EditCommand<Event> {
         for (Index index : personIndices) {
             if (index.getZeroBased() >= eventToEdit.getPersons().size()) {
                 // System.out.println();
-                throw new CommandException(String.format(MESSAGE_INVALID_PERSON_DISPLAYED_INDEX,
+                throw new CommandException(String.format(EventMessages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX,
                         index.getOneBased()));
             }
         }
@@ -80,12 +74,12 @@ public class RemovePersonFromEventCommand extends EditCommand<Event> {
 
     @Override
     public String getInvalidIndexMessage() {
-        return MESSAGE_INVALID_EVENT_DISPLAYED_INDEX;
+        return EventMessages.MESSAGE_INVALID_EVENT_DISPLAYED_INDEX;
     }
 
     @Override
     public String getDuplicateMessage() {
-        return MESSAGE_DUPLICATE_EVENT;
+        return EventMessages.MESSAGE_DUPLICATE_EVENT;
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/event/RemovePersonFromEventCommand.java
+++ b/src/main/java/seedu/address/logic/commands/event/RemovePersonFromEventCommand.java
@@ -17,7 +17,7 @@ import seedu.address.model.event.Event;
 import seedu.address.model.person.Person;
 
 /**
- * Remove some associated people from an event class
+ * Remove some associated people from an event class via index.
  */
 public class RemovePersonFromEventCommand extends EditCommand<Event> {
     public static final String COMMAND_WORD = "unlink";

--- a/src/main/java/seedu/address/logic/commands/event/RemovePersonFromEventCommand.java
+++ b/src/main/java/seedu/address/logic/commands/event/RemovePersonFromEventCommand.java
@@ -1,0 +1,88 @@
+package seedu.address.logic.commands.event;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.parser.CliSyntax.EVENT_COMMAND_WORD;
+import static seedu.address.logic.parser.event.EventCliSyntax.PREFIX_LINKED_PERSON_INDEX;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.Messages;
+import seedu.address.logic.abstractcommand.EditCommand;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.event.Event;
+import seedu.address.model.person.Person;
+
+/**
+ * Remove some associated people from an event class
+ */
+public class RemovePersonFromEventCommand extends EditCommand<Event> {
+    public static final String COMMAND_WORD = "unlink";
+
+    public static final String MESSAGE_USAGE = EVENT_COMMAND_WORD + " " + COMMAND_WORD
+            + ": Remove the association between a event and some contacts.\n"
+            + "Parameters: INDEX "
+            + PREFIX_LINKED_PERSON_INDEX + " [PERSON_INDEX]...\n"
+            + "Example: " + EVENT_COMMAND_WORD + " " + COMMAND_WORD + " 1 "
+            + PREFIX_LINKED_PERSON_INDEX + " 1 3 4";
+
+    public static final String MESSAGE_INVALID_PERSON_DISPLAYED_INDEX =
+            "The person index provided is invalid: %1$s";
+    public static final String MESSAGE_INVALID_EVENT_DISPLAYED_INDEX =
+            "The event index provided is invalid";
+    public static final String MESSAGE_REMOVE_PERSON_SUCCESS = "Removed persons from event: %1$s";
+    public static final String MESSAGE_NOT_REMOVED = "At least one person must be provided.";
+    public static final String MESSAGE_DUPLICATE_EVENT = "This event already exists";
+
+    private final List<Index> personIndices;
+
+    /**
+     * Creates an RemovePersonFromEventCommand to remove the persons at the specified {@code
+     * personIndices} from the list of persons in the event at the specified {@code index}.
+     */
+    public RemovePersonFromEventCommand(Index index, List<Index> personIndices) {
+        super(index, Model::getEventManagerAndList);
+        requireNonNull(personIndices);
+        this.personIndices = personIndices;
+    }
+
+    @Override
+    public Event createEditedItem(Model model, Event eventToEdit) throws CommandException {
+        for (Index index : personIndices) {
+            if (index.getZeroBased() >= eventToEdit.getPersons().size()) {
+                // System.out.println();
+                throw new CommandException(String.format(MESSAGE_INVALID_PERSON_DISPLAYED_INDEX,
+                        index.getOneBased()));
+            }
+        }
+        List<Person> newPersons = new ArrayList<>(eventToEdit.getPersons());
+        personIndices.stream()
+                .map(Index::getZeroBased)
+                // .sorted(Comparator.reverseOrder())
+                .forEach(index -> newPersons.remove((int) index));
+        return new Event(
+            eventToEdit.getName(),
+            eventToEdit.getStartTime(),
+            eventToEdit.getEndTime(),
+            eventToEdit.getLocation(),
+            List.copyOf(newPersons)
+        );
+    }
+
+    @Override
+    public String getInvalidIndexMessage() {
+        return MESSAGE_INVALID_EVENT_DISPLAYED_INDEX;
+    }
+
+    @Override
+    public String getDuplicateMessage() {
+        return MESSAGE_DUPLICATE_EVENT;
+    }
+
+    @Override
+    public String getSuccessMessage(Event editedItem) {
+        return String.format(MESSAGE_REMOVE_PERSON_SUCCESS, Messages.format(editedItem));
+    }
+}

--- a/src/main/java/seedu/address/logic/commands/event/RemovePersonFromLogEventCommand.java
+++ b/src/main/java/seedu/address/logic/commands/event/RemovePersonFromLogEventCommand.java
@@ -15,6 +15,9 @@ import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.event.Event;
 
+/**
+ * Removes the log of the given contacts via index.
+ */
 public class RemovePersonFromLogEventCommand extends EditCommand<Event> {
     public static final String COMMAND_WORD = "unlog";
 
@@ -56,7 +59,7 @@ public class RemovePersonFromLogEventCommand extends EditCommand<Event> {
         personIndices.stream()
                 .map(Index::getZeroBased)
                 .sorted(Comparator.reverseOrder())
-                .forEach(index -> newMarkList.add(index, false));
+                .forEach(index -> newMarkList.set(index, false));
         return new Event(
                 eventToEdit.getName(),
                 eventToEdit.getStartTime(),

--- a/src/main/java/seedu/address/logic/commands/event/RemovePersonFromLogEventCommand.java
+++ b/src/main/java/seedu/address/logic/commands/event/RemovePersonFromLogEventCommand.java
@@ -7,8 +7,10 @@ import static seedu.address.logic.parser.event.EventCliSyntax.PREFIX_LINKED_PERS
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import seedu.address.commons.core.index.Index;
+import seedu.address.logic.EventMessages;
 import seedu.address.logic.Messages;
 import seedu.address.logic.abstractcommand.EditCommand;
 import seedu.address.logic.commands.exceptions.CommandException;
@@ -27,13 +29,9 @@ public class RemovePersonFromLogEventCommand extends EditCommand<Event> {
             + PREFIX_LINKED_PERSON_INDEX + " [PERSON_INDEX] ...\n"
             + "Example: " + EVENT_COMMAND_WORD + " " + COMMAND_WORD + " 1 "
             + PREFIX_LINKED_PERSON_INDEX + " 1 2 3";
-    public static final String MESSAGE_INVALID_PERSON_DISPLAYED_INDEX =
-            "The person index provided is invalid: %1$s";
-    public static final String MESSAGE_INVALID_EVENT_DISPLAYED_INDEX =
-            "The event index provided is invalid";
     public static final String MESSAGE_REMOVE_LOG_PERSON_SUCCESS = "Removed attendance from person: %1$s";
-    public static final String MESSAGE_NOT_REMOVED = "At least one person must be provided.";
-    public static final String MESSAGE_DUPLICATE_EVENT = "This event already exists";
+    public static final String MESSAGE_PERSON_ALREADY_UNLOGGED =
+            "The person at the following index(es) are already unlogged: %s";
 
     private final List<Index> personIndices;
 
@@ -51,11 +49,21 @@ public class RemovePersonFromLogEventCommand extends EditCommand<Event> {
     public Event createEditedItem(Model model, Event eventToEdit) throws CommandException {
         for (Index index : personIndices) {
             if (index.getZeroBased() >= eventToEdit.getPersons().size()) {
-                throw new CommandException(String.format(MESSAGE_INVALID_PERSON_DISPLAYED_INDEX,
+                throw new CommandException(String.format(EventMessages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX,
                         index.getOneBased()));
             }
         }
         List<Boolean> newMarkList = new ArrayList<>(eventToEdit.getMarkedList());
+        List<Index> checkPersonMarked = personIndices.stream()
+                .filter(x -> !newMarkList.get(x.getZeroBased()))
+                .toList();
+        if (!checkPersonMarked.isEmpty()) {
+            throw new CommandException(String.format(MESSAGE_PERSON_ALREADY_UNLOGGED,
+                    checkPersonMarked.stream()
+                            .map(x -> String.valueOf(x.getOneBased()))
+                            .collect(Collectors.joining(", ")))
+            );
+        }
         personIndices.stream()
                 .map(Index::getZeroBased)
                 .sorted(Comparator.reverseOrder())
@@ -71,12 +79,12 @@ public class RemovePersonFromLogEventCommand extends EditCommand<Event> {
 
     @Override
     public String getInvalidIndexMessage() {
-        return MESSAGE_INVALID_EVENT_DISPLAYED_INDEX;
+        return EventMessages.MESSAGE_INVALID_EVENT_DISPLAYED_INDEX;
     }
 
     @Override
     public String getDuplicateMessage() {
-        return MESSAGE_DUPLICATE_EVENT;
+        return EventMessages.MESSAGE_DUPLICATE_EVENT;
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/event/RemovePersonFromLogEventCommand.java
+++ b/src/main/java/seedu/address/logic/commands/event/RemovePersonFromLogEventCommand.java
@@ -14,36 +14,31 @@ import seedu.address.logic.abstractcommand.EditCommand;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.event.Event;
-import seedu.address.model.person.Person;
 
-/**
- * Remove some associated people from an event class
- */
-public class RemovePersonFromEventCommand extends EditCommand<Event> {
-    public static final String COMMAND_WORD = "unlink";
+public class RemovePersonFromLogEventCommand extends EditCommand<Event> {
+    public static final String COMMAND_WORD = "unlog";
 
     public static final String MESSAGE_USAGE = EVENT_COMMAND_WORD + " " + COMMAND_WORD
-            + ": Remove the association between a event and some contacts.\n"
-            + "Parameters: INDEX "
-            + PREFIX_LINKED_PERSON_INDEX + " [PERSON_INDEX]...\n"
+            + ": Remove the logs for some contacts with an event.\n"
+            + "Parameter: INDEX "
+            + PREFIX_LINKED_PERSON_INDEX + " [PERSON_INDEX] ...\n"
             + "Example: " + EVENT_COMMAND_WORD + " " + COMMAND_WORD + " 1 "
-            + PREFIX_LINKED_PERSON_INDEX + " 1 3 4";
-
+            + PREFIX_LINKED_PERSON_INDEX + " 1 2 3";
     public static final String MESSAGE_INVALID_PERSON_DISPLAYED_INDEX =
             "The person index provided is invalid: %1$s";
     public static final String MESSAGE_INVALID_EVENT_DISPLAYED_INDEX =
             "The event index provided is invalid";
-    public static final String MESSAGE_REMOVE_PERSON_SUCCESS = "Removed persons from event: %1$s";
+    public static final String MESSAGE_REMOVE_LOG_PERSON_SUCCESS = "Removed attendance from person: %1$s";
     public static final String MESSAGE_NOT_REMOVED = "At least one person must be provided.";
     public static final String MESSAGE_DUPLICATE_EVENT = "This event already exists";
 
     private final List<Index> personIndices;
 
     /**
-     * Creates a RemovePersonFromEventCommand to remove the persons at the specified {@code
-     * personIndices} from the list of persons in the event at the specified {@code index}.
+     * Creates a RemovePersonFromLogEventCommand to remove the log of the
+     * persons at the specified {@code personIndices}
      */
-    public RemovePersonFromEventCommand(Index index, List<Index> personIndices) {
+    public RemovePersonFromLogEventCommand(Index index, List<Index> personIndices) {
         super(index, Model::getEventManagerAndList);
         requireNonNull(personIndices);
         this.personIndices = personIndices;
@@ -53,29 +48,22 @@ public class RemovePersonFromEventCommand extends EditCommand<Event> {
     public Event createEditedItem(Model model, Event eventToEdit) throws CommandException {
         for (Index index : personIndices) {
             if (index.getZeroBased() >= eventToEdit.getPersons().size()) {
-                // System.out.println();
                 throw new CommandException(String.format(MESSAGE_INVALID_PERSON_DISPLAYED_INDEX,
                         index.getOneBased()));
             }
         }
-        List<Person> newPersons = new ArrayList<>(eventToEdit.getPersons());
         List<Boolean> newMarkList = new ArrayList<>(eventToEdit.getMarkedList());
         personIndices.stream()
                 .map(Index::getZeroBased)
                 .sorted(Comparator.reverseOrder())
-                .forEach(index -> newPersons.remove((int) index));
-        personIndices.stream()
-                .map(Index::getZeroBased)
-                .sorted(Comparator.reverseOrder())
-                .forEach(index -> newMarkList.remove((int) index));
+                .forEach(index -> newMarkList.add(index, false));
         return new Event(
-            eventToEdit.getName(),
-            eventToEdit.getStartTime(),
-            eventToEdit.getEndTime(),
-            eventToEdit.getLocation(),
-            List.copyOf(newPersons),
-            List.copyOf(newMarkList)
-        );
+                eventToEdit.getName(),
+                eventToEdit.getStartTime(),
+                eventToEdit.getEndTime(),
+                eventToEdit.getLocation(),
+                eventToEdit.getPersons(),
+                List.copyOf(newMarkList));
     }
 
     @Override
@@ -90,6 +78,6 @@ public class RemovePersonFromEventCommand extends EditCommand<Event> {
 
     @Override
     public String getSuccessMessage(Event editedItem) {
-        return String.format(MESSAGE_REMOVE_PERSON_SUCCESS, Messages.format(editedItem));
+        return String.format(MESSAGE_REMOVE_LOG_PERSON_SUCCESS, Messages.format(editedItem));
     }
 }

--- a/src/main/java/seedu/address/logic/parser/event/AddEventCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/event/AddEventCommandParser.java
@@ -43,7 +43,7 @@ public class AddEventCommandParser implements Parser<AddEventCommand> {
         EventDateTime startTime = EventParseUtil.parseDateTime(argMultimap.getValue(PREFIX_START_DATETIME).get());
         EventDateTime endTime = EventParseUtil.parseDateTime(argMultimap.getValue(PREFIX_END_DATETIME).get());
         EventLocation location = EventParseUtil.parseLocation(argMultimap.getValue(PREFIX_EVENT_LOCATION).get());
-        if (endTime.isBefore(startTime)) {
+        if (!startTime.isBefore(endTime)) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
                     EventDateTime.MESSAGE_NEGATIVE_DURATION));
         }

--- a/src/main/java/seedu/address/logic/parser/event/AddEventCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/event/AddEventCommandParser.java
@@ -43,7 +43,10 @@ public class AddEventCommandParser implements Parser<AddEventCommand> {
         EventDateTime startTime = EventParseUtil.parseDateTime(argMultimap.getValue(PREFIX_START_DATETIME).get());
         EventDateTime endTime = EventParseUtil.parseDateTime(argMultimap.getValue(PREFIX_END_DATETIME).get());
         EventLocation location = EventParseUtil.parseLocation(argMultimap.getValue(PREFIX_EVENT_LOCATION).get());
-
+        if (endTime.isBefore(startTime)) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                    EventDateTime.MESSAGE_NEGATIVE_DURATION));
+        }
         Event event = new Event(name, startTime, endTime, location);
 
         return new AddEventCommand(event);

--- a/src/main/java/seedu/address/logic/parser/event/AddPersonToEventCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/event/AddPersonToEventCommandParser.java
@@ -1,0 +1,47 @@
+package seedu.address.logic.parser.event;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.todo.TodoCliSyntax.PREFIX_LINKED_PERSON_INDEX;
+
+import java.util.List;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.event.AddPersonToEventCommand;
+import seedu.address.logic.parser.ArgumentMultimap;
+import seedu.address.logic.parser.ArgumentTokenizer;
+import seedu.address.logic.parser.Parser;
+import seedu.address.logic.parser.ParserUtil;
+import seedu.address.logic.parser.exceptions.ParseException;
+
+/**
+ * Parses input arguments and creates a new AddPersonToEventCommandParser object
+ */
+public class AddPersonToEventCommandParser implements Parser<AddPersonToEventCommand> {
+    /**
+     * Parses the given {@code String} of arguments in the context of the
+     * AddPersonToEventCommandParser and returns a AddPersonToEventCommandParser object for
+     * execution.
+     *
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    @Override
+    public AddPersonToEventCommand parse(String args) throws ParseException {
+        requireNonNull(args);
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_LINKED_PERSON_INDEX);
+        Index index;
+        try {
+            index = ParserUtil.parseIndex(argMultimap.getPreamble());
+        } catch (ParseException pe) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                    AddPersonToEventCommand.MESSAGE_USAGE), pe);
+        }
+        argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_LINKED_PERSON_INDEX);
+        List<Index> personIndices =
+                ParserUtil.parseIndices(argMultimap.getValue(PREFIX_LINKED_PERSON_INDEX).get());
+        if (personIndices.isEmpty()) {
+            throw new ParseException(AddPersonToEventCommand.MESSAGE_NOT_ADDED);
+        }
+        return new AddPersonToEventCommand(index, personIndices);
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/event/AddPersonToEventCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/event/AddPersonToEventCommandParser.java
@@ -20,7 +20,7 @@ import seedu.address.logic.parser.exceptions.ParseException;
 public class AddPersonToEventCommandParser implements Parser<AddPersonToEventCommand> {
     /**
      * Parses the given {@code String} of arguments in the context of the
-     * AddPersonToEventCommandParser and returns a AddPersonToEventCommandParser object for
+     * AddPersonToEventCommandParser and returns a AddPersonToEventCommand object for
      * execution.
      *
      * @throws ParseException if the user input does not conform the expected format

--- a/src/main/java/seedu/address/logic/parser/event/AddPersonToEventCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/event/AddPersonToEventCommandParser.java
@@ -7,6 +7,7 @@ import static seedu.address.logic.parser.todo.TodoCliSyntax.PREFIX_LINKED_PERSON
 import java.util.List;
 
 import seedu.address.commons.core.index.Index;
+import seedu.address.logic.EventMessages;
 import seedu.address.logic.commands.event.AddPersonToEventCommand;
 import seedu.address.logic.parser.ArgumentMultimap;
 import seedu.address.logic.parser.ArgumentTokenizer;
@@ -29,6 +30,11 @@ public class AddPersonToEventCommandParser implements Parser<AddPersonToEventCom
     public AddPersonToEventCommand parse(String args) throws ParseException {
         requireNonNull(args);
         ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_LINKED_PERSON_INDEX);
+        if (!argMultimap.arePrefixesPresent(PREFIX_LINKED_PERSON_INDEX)
+                || argMultimap.getPreamble().isEmpty()) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                    AddPersonToEventCommand.MESSAGE_USAGE));
+        }
         Index index;
         try {
             index = ParserUtil.parseIndex(argMultimap.getPreamble());
@@ -40,7 +46,7 @@ public class AddPersonToEventCommandParser implements Parser<AddPersonToEventCom
         List<Index> personIndices =
                 ParserUtil.parseIndices(argMultimap.getValue(PREFIX_LINKED_PERSON_INDEX).get());
         if (personIndices.isEmpty()) {
-            throw new ParseException(AddPersonToEventCommand.MESSAGE_NOT_ADDED);
+            throw new ParseException(EventMessages.MESSAGE_NOT_REMOVED);
         }
         return new AddPersonToEventCommand(index, personIndices);
     }

--- a/src/main/java/seedu/address/logic/parser/event/AddPersonToLogEventCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/event/AddPersonToLogEventCommandParser.java
@@ -2,12 +2,12 @@ package seedu.address.logic.parser.event;
 
 import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-import static seedu.address.logic.parser.todo.TodoCliSyntax.PREFIX_LINKED_PERSON_INDEX;
+import static seedu.address.logic.parser.event.EventCliSyntax.PREFIX_LINKED_PERSON_INDEX;
 
 import java.util.List;
 
 import seedu.address.commons.core.index.Index;
-import seedu.address.logic.commands.event.RemovePersonFromEventCommand;
+import seedu.address.logic.commands.event.AddPersonToLogEventCommand;
 import seedu.address.logic.parser.ArgumentMultimap;
 import seedu.address.logic.parser.ArgumentTokenizer;
 import seedu.address.logic.parser.Parser;
@@ -15,31 +15,33 @@ import seedu.address.logic.parser.ParserUtil;
 import seedu.address.logic.parser.exceptions.ParseException;
 
 /**
- * Parses input arguments and creates a new RemovePersonFromEventCommandParser object.
+ * Parses input arguments and creates a new AddPersonToLogEventCommandParser object.
  */
-public class RemovePersonFromEventCommandParser implements Parser<RemovePersonFromEventCommand> {
+public class AddPersonToLogEventCommandParser implements Parser<AddPersonToLogEventCommand> {
+    /**
+     * Parses the given {@code String} of arguments in the context of the
+     * AddPersonToLogEventCommandParser and returns a AddPersonToLogEventCommandParser object for
+     * execution.
+     *
+     * @throws ParseException if the user input does not conform the expected format
+     */
     @Override
-    public RemovePersonFromEventCommand parse(String args) throws ParseException {
+    public AddPersonToLogEventCommand parse(String args) throws ParseException {
         requireNonNull(args);
         ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_LINKED_PERSON_INDEX);
-
         Index index;
-
         try {
             index = ParserUtil.parseIndex(argMultimap.getPreamble());
         } catch (ParseException pe) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
-                    RemovePersonFromEventCommand.MESSAGE_USAGE), pe);
+                    AddPersonToLogEventCommand.MESSAGE_USAGE), pe);
         }
-
         argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_LINKED_PERSON_INDEX);
         List<Index> personIndices =
                 ParserUtil.parseIndices(argMultimap.getValue(PREFIX_LINKED_PERSON_INDEX).get());
-
         if (personIndices.isEmpty()) {
-            throw new ParseException(RemovePersonFromEventCommand.MESSAGE_NOT_REMOVED);
+            throw new ParseException(AddPersonToLogEventCommand.MESSAGE_NOT_REMOVED);
         }
-
-        return new RemovePersonFromEventCommand(index, personIndices);
+        return new AddPersonToLogEventCommand(index, personIndices);
     }
 }

--- a/src/main/java/seedu/address/logic/parser/event/AddPersonToLogEventCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/event/AddPersonToLogEventCommandParser.java
@@ -20,7 +20,7 @@ import seedu.address.logic.parser.exceptions.ParseException;
 public class AddPersonToLogEventCommandParser implements Parser<AddPersonToLogEventCommand> {
     /**
      * Parses the given {@code String} of arguments in the context of the
-     * AddPersonToLogEventCommandParser and returns a AddPersonToLogEventCommandParser object for
+     * AddPersonToLogEventCommandParser and returns a AddPersonToLogEventCommand object for
      * execution.
      *
      * @throws ParseException if the user input does not conform the expected format

--- a/src/main/java/seedu/address/logic/parser/event/AddPersonToLogEventCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/event/AddPersonToLogEventCommandParser.java
@@ -7,6 +7,7 @@ import static seedu.address.logic.parser.event.EventCliSyntax.PREFIX_LINKED_PERS
 import java.util.List;
 
 import seedu.address.commons.core.index.Index;
+import seedu.address.logic.EventMessages;
 import seedu.address.logic.commands.event.AddPersonToLogEventCommand;
 import seedu.address.logic.parser.ArgumentMultimap;
 import seedu.address.logic.parser.ArgumentTokenizer;
@@ -29,6 +30,11 @@ public class AddPersonToLogEventCommandParser implements Parser<AddPersonToLogEv
     public AddPersonToLogEventCommand parse(String args) throws ParseException {
         requireNonNull(args);
         ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_LINKED_PERSON_INDEX);
+        if (!argMultimap.arePrefixesPresent(PREFIX_LINKED_PERSON_INDEX)
+                || argMultimap.getPreamble().isEmpty()) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                    AddPersonToLogEventCommand.MESSAGE_USAGE));
+        }
         Index index;
         try {
             index = ParserUtil.parseIndex(argMultimap.getPreamble());
@@ -40,7 +46,7 @@ public class AddPersonToLogEventCommandParser implements Parser<AddPersonToLogEv
         List<Index> personIndices =
                 ParserUtil.parseIndices(argMultimap.getValue(PREFIX_LINKED_PERSON_INDEX).get());
         if (personIndices.isEmpty()) {
-            throw new ParseException(AddPersonToLogEventCommand.MESSAGE_NOT_REMOVED);
+            throw new ParseException(EventMessages.MESSAGE_NOT_REMOVED);
         }
         return new AddPersonToLogEventCommand(index, personIndices);
     }

--- a/src/main/java/seedu/address/logic/parser/event/EventCliSyntax.java
+++ b/src/main/java/seedu/address/logic/parser/event/EventCliSyntax.java
@@ -12,4 +12,5 @@ public class EventCliSyntax {
     public static final Prefix PREFIX_START_DATETIME = new Prefix("s/");
     public static final Prefix PREFIX_END_DATETIME = new Prefix("e/");
     public static final Prefix PREFIX_EVENT_LOCATION = new Prefix("l/");
+    public static final Prefix PREFIX_LINKED_PERSON_INDEX = new Prefix("p/");
 }

--- a/src/main/java/seedu/address/logic/parser/event/EventParser.java
+++ b/src/main/java/seedu/address/logic/parser/event/EventParser.java
@@ -12,10 +12,12 @@ import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.event.AddEventCommand;
 import seedu.address.logic.commands.event.AddPersonToEventCommand;
+import seedu.address.logic.commands.event.AddPersonToLogEventCommand;
 import seedu.address.logic.commands.event.DeleteEventCommand;
 import seedu.address.logic.commands.event.DisplayEventInformationCommand;
 import seedu.address.logic.commands.event.ListEventCommand;
 import seedu.address.logic.commands.event.RemovePersonFromEventCommand;
+import seedu.address.logic.commands.event.RemovePersonFromLogEventCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 
 /**
@@ -71,6 +73,12 @@ public class EventParser {
 
         case RemovePersonFromEventCommand.COMMAND_WORD:
             return new RemovePersonFromEventCommandParser().parse(arguments);
+
+        case AddPersonToLogEventCommand.COMMAND_WORD:
+            return new AddPersonToLogEventCommandParser().parse(arguments);
+
+        case RemovePersonFromLogEventCommand.COMMAND_WORD:
+            return new RemovePersonFromLogEventCommandParser().parse(arguments);
 
         default:
             logger.finer("This user input caused a ParseException: " + userInput);

--- a/src/main/java/seedu/address/logic/parser/event/EventParser.java
+++ b/src/main/java/seedu/address/logic/parser/event/EventParser.java
@@ -11,9 +11,11 @@ import seedu.address.commons.core.LogsCenter;
 import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.event.AddEventCommand;
+import seedu.address.logic.commands.event.AddPersonToEventCommand;
 import seedu.address.logic.commands.event.DeleteEventCommand;
 import seedu.address.logic.commands.event.DisplayEventInformationCommand;
 import seedu.address.logic.commands.event.ListEventCommand;
+import seedu.address.logic.commands.event.RemovePersonFromEventCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 
 /**
@@ -63,6 +65,12 @@ public class EventParser {
 
         case DeleteEventCommand.COMMAND_WORD:
             return new DeleteEventCommandParser().parse(arguments);
+
+        case AddPersonToEventCommand.COMMAND_WORD:
+            return new AddPersonToEventCommandParser().parse(arguments);
+
+        case RemovePersonFromEventCommand.COMMAND_WORD:
+            return new RemovePersonFromEventCommandParser().parse(arguments);
 
         default:
             logger.finer("This user input caused a ParseException: " + userInput);

--- a/src/main/java/seedu/address/logic/parser/event/RemovePersonFromEventCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/event/RemovePersonFromEventCommandParser.java
@@ -1,0 +1,45 @@
+package seedu.address.logic.parser.event;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.todo.TodoCliSyntax.PREFIX_LINKED_PERSON_INDEX;
+
+import java.util.List;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.event.RemovePersonFromEventCommand;
+import seedu.address.logic.parser.ArgumentMultimap;
+import seedu.address.logic.parser.ArgumentTokenizer;
+import seedu.address.logic.parser.Parser;
+import seedu.address.logic.parser.ParserUtil;
+import seedu.address.logic.parser.exceptions.ParseException;
+
+/**
+ * Parses input arguments and creates a new RemovePersonFromEventCommandParser object
+ */
+public class RemovePersonFromEventCommandParser implements Parser<RemovePersonFromEventCommand> {
+    @Override
+    public RemovePersonFromEventCommand parse(String args) throws ParseException {
+        requireNonNull(args);
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_LINKED_PERSON_INDEX);
+
+        Index index;
+
+        try {
+            index = ParserUtil.parseIndex(argMultimap.getPreamble());
+        } catch (ParseException pe) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                    RemovePersonFromEventCommand.MESSAGE_USAGE), pe);
+        }
+
+        argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_LINKED_PERSON_INDEX);
+        List<Index> personIndices =
+                ParserUtil.parseIndices(argMultimap.getValue(PREFIX_LINKED_PERSON_INDEX).get());
+
+        if (personIndices.isEmpty()) {
+            throw new ParseException(RemovePersonFromEventCommand.MESSAGE_NOT_REMOVED);
+        }
+
+        return new RemovePersonFromEventCommand(index, personIndices);
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/event/RemovePersonFromEventCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/event/RemovePersonFromEventCommandParser.java
@@ -7,6 +7,7 @@ import static seedu.address.logic.parser.todo.TodoCliSyntax.PREFIX_LINKED_PERSON
 import java.util.List;
 
 import seedu.address.commons.core.index.Index;
+import seedu.address.logic.EventMessages;
 import seedu.address.logic.commands.event.RemovePersonFromEventCommand;
 import seedu.address.logic.parser.ArgumentMultimap;
 import seedu.address.logic.parser.ArgumentTokenizer;
@@ -22,7 +23,11 @@ public class RemovePersonFromEventCommandParser implements Parser<RemovePersonFr
     public RemovePersonFromEventCommand parse(String args) throws ParseException {
         requireNonNull(args);
         ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_LINKED_PERSON_INDEX);
-
+        if (!argMultimap.arePrefixesPresent(PREFIX_LINKED_PERSON_INDEX)
+                || argMultimap.getPreamble().isEmpty()) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                    RemovePersonFromEventCommand.MESSAGE_USAGE));
+        }
         Index index;
 
         try {
@@ -37,7 +42,7 @@ public class RemovePersonFromEventCommandParser implements Parser<RemovePersonFr
                 ParserUtil.parseIndices(argMultimap.getValue(PREFIX_LINKED_PERSON_INDEX).get());
 
         if (personIndices.isEmpty()) {
-            throw new ParseException(RemovePersonFromEventCommand.MESSAGE_NOT_REMOVED);
+            throw new ParseException(EventMessages.MESSAGE_NOT_REMOVED);
         }
 
         return new RemovePersonFromEventCommand(index, personIndices);

--- a/src/main/java/seedu/address/logic/parser/event/RemovePersonFromLogEventCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/event/RemovePersonFromLogEventCommandParser.java
@@ -7,6 +7,7 @@ import static seedu.address.logic.parser.event.EventCliSyntax.PREFIX_LINKED_PERS
 import java.util.List;
 
 import seedu.address.commons.core.index.Index;
+import seedu.address.logic.EventMessages;
 import seedu.address.logic.commands.event.RemovePersonFromLogEventCommand;
 import seedu.address.logic.parser.ArgumentMultimap;
 import seedu.address.logic.parser.ArgumentTokenizer;
@@ -29,6 +30,11 @@ public class RemovePersonFromLogEventCommandParser implements Parser<RemovePerso
     public RemovePersonFromLogEventCommand parse(String args) throws ParseException {
         requireNonNull(args);
         ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_LINKED_PERSON_INDEX);
+        if (!argMultimap.arePrefixesPresent(PREFIX_LINKED_PERSON_INDEX)
+                || argMultimap.getPreamble().isEmpty()) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                    RemovePersonFromLogEventCommand.MESSAGE_USAGE));
+        }
         Index index;
         try {
             index = ParserUtil.parseIndex(argMultimap.getPreamble());
@@ -39,7 +45,7 @@ public class RemovePersonFromLogEventCommandParser implements Parser<RemovePerso
         argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_LINKED_PERSON_INDEX);
         List<Index> personIndices = ParserUtil.parseIndices(argMultimap.getValue(PREFIX_LINKED_PERSON_INDEX).get());
         if (personIndices.isEmpty()) {
-            throw new ParseException(RemovePersonFromLogEventCommand.MESSAGE_NOT_REMOVED);
+            throw new ParseException(EventMessages.MESSAGE_NOT_REMOVED);
         }
         return new RemovePersonFromLogEventCommand(index, personIndices);
     }

--- a/src/main/java/seedu/address/logic/parser/event/RemovePersonFromLogEventCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/event/RemovePersonFromLogEventCommandParser.java
@@ -1,0 +1,46 @@
+package seedu.address.logic.parser.event;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.event.EventCliSyntax.PREFIX_LINKED_PERSON_INDEX;
+
+import java.util.List;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.event.RemovePersonFromLogEventCommand;
+import seedu.address.logic.parser.ArgumentMultimap;
+import seedu.address.logic.parser.ArgumentTokenizer;
+import seedu.address.logic.parser.Parser;
+import seedu.address.logic.parser.ParserUtil;
+import seedu.address.logic.parser.exceptions.ParseException;
+
+/**
+ * Parses input arguments and creates a new RemovePersonFromLogEventCommandParser object.
+ */
+public class RemovePersonFromLogEventCommandParser implements Parser<RemovePersonFromLogEventCommand> {
+    /**
+     * Parses the given {@code String} of arguments in the context of the
+     * AddPersonToLogEventCommandParser and returns a AddPersonToLogEventCommandParser object for
+     * execution.
+     *
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    @Override
+    public RemovePersonFromLogEventCommand parse(String args) throws ParseException {
+        requireNonNull(args);
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_LINKED_PERSON_INDEX);
+        Index index;
+        try {
+            index = ParserUtil.parseIndex(argMultimap.getPreamble());
+        } catch (ParseException pe) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                    RemovePersonFromLogEventCommand.MESSAGE_USAGE), pe);
+        }
+        argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_LINKED_PERSON_INDEX);
+        List<Index> personIndices = ParserUtil.parseIndices(argMultimap.getValue(PREFIX_LINKED_PERSON_INDEX).get());
+        if (personIndices.isEmpty()) {
+            throw new ParseException(RemovePersonFromLogEventCommand.MESSAGE_NOT_REMOVED);
+        }
+        return new RemovePersonFromLogEventCommand(index, personIndices);
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/event/RemovePersonFromLogEventCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/event/RemovePersonFromLogEventCommandParser.java
@@ -20,7 +20,7 @@ import seedu.address.logic.parser.exceptions.ParseException;
 public class RemovePersonFromLogEventCommandParser implements Parser<RemovePersonFromLogEventCommand> {
     /**
      * Parses the given {@code String} of arguments in the context of the
-     * AddPersonToLogEventCommandParser and returns a AddPersonToLogEventCommandParser object for
+     * AddPersonToLogEventCommandParser and returns a AddPersonToLogEventCommand object for
      * execution.
      *
      * @throws ParseException if the user input does not conform the expected format

--- a/src/main/java/seedu/address/model/event/Event.java
+++ b/src/main/java/seedu/address/model/event/Event.java
@@ -41,6 +41,7 @@ public class Event implements Item {
      */
     public Event(EventName name, EventDateTime startTime,
             EventDateTime endTime, EventLocation location) {
+        requireAllNonNull(name, startTime, endTime, location);
         this.name = name;
         this.startTime = startTime;
         this.endTime = endTime;

--- a/src/main/java/seedu/address/model/event/Event.java
+++ b/src/main/java/seedu/address/model/event/Event.java
@@ -2,10 +2,12 @@ package seedu.address.model.event;
 
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
+import java.util.List;
 import java.util.Objects;
 
 import seedu.address.commons.util.ToStringBuilder;
 import seedu.address.model.item.Item;
+import seedu.address.model.person.Person;
 
 /**
  * Represents an Event.
@@ -16,17 +18,31 @@ public class Event implements Item {
     private final EventDateTime startTime;
     private final EventDateTime endTime;
     private final EventLocation location;
+    private final List<Person> persons;
+
+    /**
+     * Every field must be present and not null, field values are validated, immutable.
+     */
+    public Event(EventName name, EventDateTime startTime,
+            EventDateTime endTime, EventLocation location, List<Person> persons) {
+        requireAllNonNull(name, startTime, endTime, location, persons);
+        this.name = name;
+        this.startTime = startTime;
+        this.endTime = endTime;
+        this.location = location;
+        this.persons = persons;
+    }
 
     /**
      * Every field must be present and not null, field values are validated, immutable.
      */
     public Event(EventName name, EventDateTime startTime,
             EventDateTime endTime, EventLocation location) {
-        requireAllNonNull(name, startTime, endTime, location);
         this.name = name;
         this.startTime = startTime;
         this.endTime = endTime;
         this.location = location;
+        this.persons = List.of();
     }
 
     public EventName getName() {
@@ -45,6 +61,10 @@ public class Event implements Item {
         return this.location;
     }
 
+    public List<Person> getPersons() {
+        return this.persons;
+    }
+
     @Override
     public String toString() {
         return new ToStringBuilder(this)
@@ -52,6 +72,7 @@ public class Event implements Item {
                 .add("start_time", startTime)
                 .add("end_time", endTime)
                 .add("location", location)
+                .add("persons", persons)
                 .toString();
     }
 
@@ -66,11 +87,12 @@ public class Event implements Item {
         return this.name.equals(otherEvent.name)
                 && this.startTime.equals(otherEvent.startTime)
                 && this.endTime.equals(otherEvent.endTime)
-                && this.location.equals(otherEvent.location);
+                && this.location.equals(otherEvent.location)
+                && this.persons.equals(otherEvent.persons);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(name, startTime, endTime, location);
+        return Objects.hash(name, startTime, endTime, location, persons);
     }
 }

--- a/src/main/java/seedu/address/model/event/Event.java
+++ b/src/main/java/seedu/address/model/event/Event.java
@@ -19,18 +19,21 @@ public class Event implements Item {
     private final EventDateTime endTime;
     private final EventLocation location;
     private final List<Person> persons;
+    private final List<Boolean> markedList;
 
     /**
      * Every field must be present and not null, field values are validated, immutable.
      */
     public Event(EventName name, EventDateTime startTime,
-            EventDateTime endTime, EventLocation location, List<Person> persons) {
+            EventDateTime endTime, EventLocation location,
+            List<Person> persons, List<Boolean> markedList) {
         requireAllNonNull(name, startTime, endTime, location, persons);
         this.name = name;
         this.startTime = startTime;
         this.endTime = endTime;
         this.location = location;
         this.persons = persons;
+        this.markedList = markedList;
     }
 
     /**
@@ -43,6 +46,7 @@ public class Event implements Item {
         this.endTime = endTime;
         this.location = location;
         this.persons = List.of();
+        this.markedList = List.of();
     }
 
     public EventName getName() {
@@ -65,6 +69,10 @@ public class Event implements Item {
         return this.persons;
     }
 
+    public List<Boolean> getMarkedList() {
+        return this.markedList;
+    }
+
     @Override
     public String toString() {
         return new ToStringBuilder(this)
@@ -73,6 +81,7 @@ public class Event implements Item {
                 .add("end_time", endTime)
                 .add("location", location)
                 .add("persons", persons)
+                .add("marked_contacts", markedList)
                 .toString();
     }
 
@@ -88,11 +97,12 @@ public class Event implements Item {
                 && this.startTime.equals(otherEvent.startTime)
                 && this.endTime.equals(otherEvent.endTime)
                 && this.location.equals(otherEvent.location)
-                && this.persons.equals(otherEvent.persons);
+                && this.persons.equals(otherEvent.persons)
+                && this.markedList.equals(otherEvent.markedList);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(name, startTime, endTime, location, persons);
+        return Objects.hash(name, startTime, endTime, location, persons, markedList);
     }
 }

--- a/src/main/java/seedu/address/model/event/EventDateTime.java
+++ b/src/main/java/seedu/address/model/event/EventDateTime.java
@@ -14,6 +14,7 @@ import java.time.format.DateTimeParseException;
 public class EventDateTime {
     public static final String MESSAGE_CONSTRAINTS =
             "Event start/end time should be in the format YY-MM-DD HH:MM, where HH is in 24-hour format.";
+    public static final String MESSAGE_NEGATIVE_DURATION = "The given Event end time is earlier than it's start time.";
     public static final DateTimeFormatter DATE_TIME_FORMATTER = DateTimeFormatter.ofPattern("yy-MM-dd HH:mm");
     public final LocalDateTime dateTime;
 
@@ -38,6 +39,10 @@ public class EventDateTime {
         } catch (DateTimeParseException e) {
             return false;
         }
+    }
+
+    public boolean isBefore(EventDateTime otherEventDateTime) {
+        return this.dateTime.isBefore(otherEventDateTime.dateTime);
     }
 
     @Override

--- a/src/main/java/seedu/address/model/event/EventDateTime.java
+++ b/src/main/java/seedu/address/model/event/EventDateTime.java
@@ -14,7 +14,8 @@ import java.time.format.DateTimeParseException;
 public class EventDateTime {
     public static final String MESSAGE_CONSTRAINTS =
             "Event start/end time should be in the format YY-MM-DD HH:MM, where HH is in 24-hour format.";
-    public static final String MESSAGE_NEGATIVE_DURATION = "The given Event end time is earlier than it's start time.";
+    public static final String MESSAGE_NEGATIVE_DURATION =
+            "The given event start-time is not before the given end-time.";
     public static final DateTimeFormatter DATE_TIME_FORMATTER = DateTimeFormatter.ofPattern("yy-MM-dd HH:mm");
     public final LocalDateTime dateTime;
 


### PR DESCRIPTION
Linking and Logging for contacts in the event class. Here are some of the command line for you to try.

The PR for adding and removing Linking for `Person` is closed as there are sufficient overlaps in this PR here as linking is needed to making logging work.

`event add n/CS2030 tutorial s/24-08-26 12:00 e/24-08-25 12:00 l/NUS SoC COM1`
`event add n/CS2030 tutorial s/24-02-31 12:00 e/24-02-31 12:00 l/NUS SoC COM1`
`event add n/CS2040S tutorial s/24-08-26 12:00 e/24-08-26 14:00 l/NUS SoC COM1`
`event link 1 p/ 1 3 4`
`event log 1 p/ 1 2 3`
`event unlog 1 p/ 1 3`
`event unlink 1 p/ 2`

Marking is similar to how it is done in iP with a square checkbox as seen in `Messages.java`.

Fixes #103 
Fixes #104