### PR TITLE
[#64] Improve `filter` command to filter contact fields and add support for union/intersection filtering

### DIFF
--- a/src/main/java/seedu/address/logic/Messages.java
+++ b/src/main/java/seedu/address/logic/Messages.java
@@ -23,6 +23,12 @@ public class Messages {
                 "Multiple values specified for the following single-valued field(s): ";
     public static final String MESSAGE_DISPLAY_SPECIFIC_PERSON_INFO = "Displaying full information of student: %s!";
 
+    public static final String MESSAGE_DUPLICATE_COLUMN = "Duplicate column: %s.";
+    public static final String MESSAGE_NO_COLUMNS = "Specify at least one column and value.";
+    public static final String MESSAGE_NO_VALUES = "No values specified for column '%s'.";
+    public static final String MESSAGE_UNRECOGNIZED_COLUMN = "Unrecognized column: '%s'.";
+    public static final String MESSAGE_UNRECOGNIZED_OPERATOR = "Unrecognized operator: '%s'.";
+
     /**
      * Returns an error message indicating the duplicate prefixes.
      */

--- a/src/main/java/seedu/address/logic/abstractcommand/FilterCommand.java
+++ b/src/main/java/seedu/address/logic/abstractcommand/FilterCommand.java
@@ -1,0 +1,51 @@
+package seedu.address.logic.abstractcommand;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.function.Function;
+import java.util.function.Predicate;
+
+import seedu.address.logic.commands.CommandResult;
+import seedu.address.model.Model;
+import seedu.address.model.item.Item;
+import seedu.address.model.item.ItemManagerWithFilteredList;
+
+/**
+ * Abstract command for filtering items in the model that match a given complex {@code predicate}.
+ *
+ * @param <T> the type of {@code Item} being filtered, which must extend {@link Item}.
+ */
+public abstract class FilterCommand<T extends Item> extends ItemCommand<T> {
+
+    protected final Predicate<T> predicate;
+
+    /**
+     * Creates a {@code FilterCommand} to filter items that match the given {@code predicate}.
+     *
+     * @throws NullPointerException if {@code predicate} or {@code managerAndListGetter} is
+     *                              {@code null}.
+     */
+    public FilterCommand(Predicate<T> predicate,
+                         Function<Model, ItemManagerWithFilteredList<T>> managerAndListGetter) {
+        super(managerAndListGetter);
+        requireNonNull(predicate);
+        this.predicate = predicate;
+    }
+
+    @Override
+    public CommandResult execute(Model model) {
+        requireNonNull(model);
+
+        ItemManagerWithFilteredList<T> managerAndList = managerAndListGetter.apply(model);
+
+        managerAndList.updateFilteredItemsList(predicate);
+        return new CommandResult(
+                getResultOverviewMessage(managerAndList.getFilteredItemsList().size()));
+    }
+
+    /**
+     * Returns an overview message about the result of the filter operation, including the
+     * number of items that match the filter criteria.
+     */
+    public abstract String getResultOverviewMessage(int numberOfResults);
+}

--- a/src/main/java/seedu/address/logic/abstractcommand/FilterCommand.java
+++ b/src/main/java/seedu/address/logic/abstractcommand/FilterCommand.java
@@ -22,8 +22,10 @@ public abstract class FilterCommand<T extends Item> extends ItemCommand<T> {
     /**
      * Creates a {@code FilterCommand} to filter items that match the given {@code predicate}.
      *
+     * @param predicate the predicate used to filter items
+     * @param managerAndListGetter function that returns the item manager and filtered list
      * @throws NullPointerException if {@code predicate} or {@code managerAndListGetter} is
-     *                              {@code null}.
+     *                              {@code null}
      */
     public FilterCommand(Predicate<T> predicate,
                          Function<Model, ItemManagerWithFilteredList<T>> managerAndListGetter) {
@@ -46,6 +48,9 @@ public abstract class FilterCommand<T extends Item> extends ItemCommand<T> {
     /**
      * Returns an overview message about the result of the filter operation, including the
      * number of items that match the filter criteria.
+     *
+     * @param numberOfResults the number of items that match the filter criteria
+     * @return a string containing the overview message
      */
     public abstract String getResultOverviewMessage(int numberOfResults);
 }

--- a/src/main/java/seedu/address/logic/commands/person/FilterPersonCommand.java
+++ b/src/main/java/seedu/address/logic/commands/person/FilterPersonCommand.java
@@ -1,0 +1,71 @@
+package seedu.address.logic.commands.person;
+
+import static seedu.address.logic.parser.CliSyntax.PREFIX_COURSE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_GROUP;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_ID;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
+
+import seedu.address.commons.util.ToStringBuilder;
+import seedu.address.logic.Messages;
+import seedu.address.logic.abstractcommand.FilterCommand;
+import seedu.address.model.Model;
+import seedu.address.model.person.Person;
+import seedu.address.model.person.PersonPredicate;
+
+/**
+ * Filters and lists all persons in address book based on specified criteria.
+ * Filter criteria are formed with columns, operators, and values.
+ */
+public class FilterPersonCommand extends FilterCommand<Person> {
+
+    public static final String COMMAND_WORD = "filter";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Filters persons based on specified criteria "
+            + "and displays them as a list with index numbers.\n"
+            + "Parameters: <col>/ [<op>:] <value(s)> [...]\n"
+            + "- <col>/ : Column to filter on (" + PREFIX_NAME + ", " + PREFIX_PHONE + ", " + PREFIX_EMAIL + ", "
+            + PREFIX_ID + ", " + PREFIX_COURSE + ", " + PREFIX_GROUP + ", " + PREFIX_TAG + ")\n"
+            + "- <op>: : Operator (and, or, nand, nor). Defaults to 'and' if not specified\n"
+            + "- <value(s)>: One or more values to filter by. Use quotes for values with spaces.\n"
+            + "Examples:\n"
+            + "1. " + COMMAND_WORD + " " + PREFIX_ID + " or: 12 13\n"
+            + "   Find students with ID 12 or 13.\n"
+            + "2. " + COMMAND_WORD + " " + PREFIX_NAME + "\"Darren Tan\" " + PREFIX_COURSE + " CS1010S "
+            + PREFIX_GROUP + "or: T01 T02 T03\n"
+            + "   Find contacts with \"Darren Tan\" in their name who enroll in course CS1010S and class T01, T02, or T03.\n"
+            + "3. " + COMMAND_WORD + " " + PREFIX_NAME + "nand: \"My enemy\" Hater " + PREFIX_TAG + "and: handsome smart\n"
+            + "   Find contacts whose names do not contain \"My enemy\" and \"Hater\" and are tagged with both \"handsome\" and \"smart\".";
+
+    public FilterPersonCommand(PersonPredicate predicate) {
+        super(predicate, Model::getPersonManagerAndList);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof FilterPersonCommand otherFilterCommand)) {
+            return false;
+        }
+
+        return predicate.equals(otherFilterCommand.predicate);
+    }
+
+    @Override
+    public String getResultOverviewMessage(int numberOfResults) {
+        return String.format(Messages.MESSAGE_PERSONS_LISTED_OVERVIEW, numberOfResults);
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this)
+                .add("predicate", predicate)
+                .toString();
+    }
+}

--- a/src/main/java/seedu/address/logic/commands/person/FilterPersonCommand.java
+++ b/src/main/java/seedu/address/logic/commands/person/FilterPersonCommand.java
@@ -35,9 +35,12 @@ public class FilterPersonCommand extends FilterCommand<Person> {
             + "   Find students with ID 12 or 13.\n"
             + "2. " + COMMAND_WORD + " " + PREFIX_NAME + "\"Darren Tan\" " + PREFIX_COURSE + " CS1010S "
             + PREFIX_GROUP + "or: T01 T02 T03\n"
-            + "   Find contacts with \"Darren Tan\" in their name who enroll in course CS1010S and class T01, T02, or T03.\n"
-            + "3. " + COMMAND_WORD + " " + PREFIX_NAME + "nand: \"My enemy\" Hater " + PREFIX_TAG + "and: handsome smart\n"
-            + "   Find contacts whose names do not contain \"My enemy\" and \"Hater\" and are tagged with both \"handsome\" and \"smart\".";
+            + "   Find contacts with \"Darren Tan\" in their name who"
+            + " enroll in course CS1010S and class T01, T02, or T03.\n"
+            + "3. " + COMMAND_WORD + " " + PREFIX_NAME + "nand: \"My enemy\" Hater "
+            + PREFIX_TAG + "and: handsome smart\n"
+            + "   Find contacts whose names do not contain \"My enemy\" and"
+            + " \"Hater\" and are tagged with both \"handsome\" and \"smart\".";
 
     /**
      * Constructs a FilterPersonCommand with the given predicate.

--- a/src/main/java/seedu/address/logic/commands/person/FilterPersonCommand.java
+++ b/src/main/java/seedu/address/logic/commands/person/FilterPersonCommand.java
@@ -39,6 +39,11 @@ public class FilterPersonCommand extends FilterCommand<Person> {
             + "3. " + COMMAND_WORD + " " + PREFIX_NAME + "nand: \"My enemy\" Hater " + PREFIX_TAG + "and: handsome smart\n"
             + "   Find contacts whose names do not contain \"My enemy\" and \"Hater\" and are tagged with both \"handsome\" and \"smart\".";
 
+    /**
+     * Constructs a FilterPersonCommand with the given predicate.
+     *
+     * @param predicate the predicate used to filter persons
+     */
     public FilterPersonCommand(PersonPredicate predicate) {
         super(predicate, Model::getPersonManagerAndList);
     }

--- a/src/main/java/seedu/address/logic/parser/ParserImpl.java
+++ b/src/main/java/seedu/address/logic/parser/ParserImpl.java
@@ -17,6 +17,7 @@ import seedu.address.logic.commands.person.AddPersonCommand;
 import seedu.address.logic.commands.person.ClearPersonCommand;
 import seedu.address.logic.commands.person.DeletePersonCommand;
 import seedu.address.logic.commands.person.EditPersonCommand;
+import seedu.address.logic.commands.person.FilterPersonCommand;
 import seedu.address.logic.commands.person.FindPersonCommand;
 import seedu.address.logic.commands.person.InfoPersonCommand;
 import seedu.address.logic.commands.person.ListPersonCommand;
@@ -25,6 +26,7 @@ import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.logic.parser.person.AddPersonCommandParser;
 import seedu.address.logic.parser.person.DeletePersonCommandParser;
 import seedu.address.logic.parser.person.EditPersonCommandParser;
+import seedu.address.logic.parser.person.FilterPersonCommandParser;
 import seedu.address.logic.parser.person.FindPersonCommandParser;
 import seedu.address.logic.parser.person.InfoPersonCommandParser;
 import seedu.address.logic.parser.todo.TodoParser;
@@ -86,6 +88,9 @@ public class ParserImpl {
 
         case InfoPersonCommand.COMMAND_WORD:
             return new InfoPersonCommandParser().parse(arguments);
+
+        case FilterPersonCommand.COMMAND_WORD:
+            return new FilterPersonCommandParser().parse(arguments);
 
         case ExitCommand.COMMAND_WORD_EXIT, ExitCommand.COMMAND_WORD_BYE,
              ExitCommand.COMMAND_WORD_QUIT, ExitCommand.COMMAND_WORD_KILL:

--- a/src/main/java/seedu/address/logic/parser/person/FilterPersonCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/person/FilterPersonCommandParser.java
@@ -8,11 +8,11 @@ import static seedu.address.logic.Messages.MESSAGE_UNRECOGNIZED_COLUMN;
 import static seedu.address.logic.Messages.MESSAGE_UNRECOGNIZED_OPERATOR;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_COURSE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_GROUP;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ID;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_GROUP;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -28,13 +28,14 @@ import seedu.address.logic.parser.ArgumentTokenizer;
 import seedu.address.logic.parser.Parser;
 import seedu.address.logic.parser.Prefix;
 import seedu.address.logic.parser.exceptions.ParseException;
-import seedu.address.model.person.FilterCriteria;
-import seedu.address.model.person.PersonPredicate;
 import seedu.address.model.person.Column;
+import seedu.address.model.person.FilterCriteria;
 import seedu.address.model.person.Operator;
+import seedu.address.model.person.PersonPredicate;
 
 /**
  * Parses input arguments and creates a new FilterPersonCommand object.
+ * Handles complex filter criteria with different operators and values.
  */
 public class FilterPersonCommandParser implements Parser<FilterPersonCommand> {
 
@@ -42,6 +43,13 @@ public class FilterPersonCommandParser implements Parser<FilterPersonCommand> {
 
     private static final Pattern QUOTED_VALUE_PATTERN = Pattern.compile("\"([^\"]*)\"");
 
+    /**
+     * Converts a prefix to its corresponding column.
+     *
+     * @param prefix the prefix to convert
+     * @return the corresponding column
+     * @throws ParseException if the prefix does not correspond to a valid column
+     */
     private Column getColumnFromPrefix(Prefix prefix) throws ParseException {
         String prefixStr = prefix.getPrefix();
 
@@ -64,7 +72,17 @@ public class FilterPersonCommandParser implements Parser<FilterPersonCommand> {
         }
     }
 
-    private void parsePrefixes(List<Prefix> allPrefixes, ArgumentMultimap argMultimap, Map<Column, FilterCriteria> filterCriteriaMap) throws ParseException {
+    /**
+     * Parses all prefixes in the argument multimap and adds the corresponding filter criteria
+     * to the provided map.
+     *
+     * @param allPrefixes the list of all prefixes to parse
+     * @param argMultimap the argument multimap containing the parsed arguments
+     * @param filterCriteriaMap the map to store the parsed filter criteria
+     * @throws ParseException if there is an error parsing any prefix
+     */
+    private void parsePrefixes(List<Prefix> allPrefixes, ArgumentMultimap argMultimap,
+                               Map<Column, FilterCriteria> filterCriteriaMap) throws ParseException {
         for (Prefix prefix : allPrefixes) {
             List<String> rawValues = argMultimap.getAllValues(prefix);
             if (rawValues.isEmpty()) {
@@ -83,7 +101,18 @@ public class FilterPersonCommandParser implements Parser<FilterPersonCommand> {
         }
     }
 
-    private void parseValues(Prefix prefix, Column column, Map<Column, FilterCriteria> filterCriteriaMap, List<String> rawValues) throws ParseException {
+    /**
+     * Parses the values for a specific prefix and adds the corresponding filter criteria
+     * to the provided map.
+     *
+     * @param prefix the prefix being parsed
+     * @param column the column corresponding to the prefix
+     * @param filterCriteriaMap the map to store the parsed filter criteria
+     * @param rawValues the list of raw values to parse
+     * @throws ParseException if there is an error parsing the values
+     */
+    private void parseValues(Prefix prefix, Column column, Map<Column, FilterCriteria> filterCriteriaMap,
+                             List<String> rawValues) throws ParseException {
         if (filterCriteriaMap.containsKey(column)) {
             throw new ParseException(MESSAGE_DUPLICATE_COLUMN);
         }
@@ -152,6 +181,12 @@ public class FilterPersonCommandParser implements Parser<FilterPersonCommand> {
         return new FilterPersonCommand(new PersonPredicate(filterCriteriaMap));
     }
 
+    /**
+     * Extracts individual values from an input string, handling both quoted and unquoted values.
+     *
+     * @param input the input string to extract values from
+     * @return a list of extracted values
+     */
     private List<String> extractValues(String input) {
         List<String> values = new ArrayList<>();
         Matcher quotedValueMatcher = QUOTED_VALUE_PATTERN.matcher(input);

--- a/src/main/java/seedu/address/logic/parser/person/FilterPersonCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/person/FilterPersonCommandParser.java
@@ -207,9 +207,7 @@ public class FilterPersonCommandParser implements Parser<FilterPersonCommand> {
                     }
                 }
             }
-        }
-
-        else if (values.isEmpty() && !input.trim().isEmpty()) {
+        } else if (values.isEmpty() && !input.trim().isEmpty()) {
             for (String value : input.trim().split("\\s+")) {
                 if (!value.trim().isEmpty()) {
                     values.add(value.trim());

--- a/src/main/java/seedu/address/logic/parser/person/FilterPersonCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/person/FilterPersonCommandParser.java
@@ -22,7 +22,6 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import seedu.address.logic.commands.person.FilterPersonCommand;
-import seedu.address.logic.commands.person.FindPersonCommand;
 import seedu.address.logic.parser.ArgumentMultimap;
 import seedu.address.logic.parser.ArgumentTokenizer;
 import seedu.address.logic.parser.Parser;
@@ -76,8 +75,8 @@ public class FilterPersonCommandParser implements Parser<FilterPersonCommand> {
      * Parses all prefixes in the argument multimap and adds the corresponding filter criteria
      * to the provided map.
      *
-     * @param allPrefixes the list of all prefixes to parse
-     * @param argMultimap the argument multimap containing the parsed arguments
+     * @param allPrefixes       the list of all prefixes to parse
+     * @param argMultimap       the argument multimap containing the parsed arguments
      * @param filterCriteriaMap the map to store the parsed filter criteria
      * @throws ParseException if there is an error parsing any prefix
      */
@@ -105,10 +104,10 @@ public class FilterPersonCommandParser implements Parser<FilterPersonCommand> {
      * Parses the values for a specific prefix and adds the corresponding filter criteria
      * to the provided map.
      *
-     * @param prefix the prefix being parsed
-     * @param column the column corresponding to the prefix
+     * @param prefix            the prefix being parsed
+     * @param column            the column corresponding to the prefix
      * @param filterCriteriaMap the map to store the parsed filter criteria
-     * @param rawValues the list of raw values to parse
+     * @param rawValues         the list of raw values to parse
      * @throws ParseException if there is an error parsing the values
      */
     private void parseValues(Prefix prefix, Column column, Map<Column, FilterCriteria> filterCriteriaMap,
@@ -161,7 +160,7 @@ public class FilterPersonCommandParser implements Parser<FilterPersonCommand> {
     public FilterPersonCommand parse(String args) throws ParseException {
         if (args.trim().isEmpty()) {
             throw new ParseException(
-                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindPersonCommand.MESSAGE_USAGE));
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, FilterPersonCommand.MESSAGE_USAGE));
         }
 
         ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args,

--- a/src/main/java/seedu/address/logic/parser/person/FilterPersonCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/person/FilterPersonCommandParser.java
@@ -1,0 +1,184 @@
+package seedu.address.logic.parser.person;
+
+import static seedu.address.logic.Messages.MESSAGE_DUPLICATE_COLUMN;
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.Messages.MESSAGE_NO_COLUMNS;
+import static seedu.address.logic.Messages.MESSAGE_NO_VALUES;
+import static seedu.address.logic.Messages.MESSAGE_UNRECOGNIZED_COLUMN;
+import static seedu.address.logic.Messages.MESSAGE_UNRECOGNIZED_OPERATOR;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_COURSE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_ID;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_GROUP;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import seedu.address.logic.commands.person.FilterPersonCommand;
+import seedu.address.logic.commands.person.FindPersonCommand;
+import seedu.address.logic.parser.ArgumentMultimap;
+import seedu.address.logic.parser.ArgumentTokenizer;
+import seedu.address.logic.parser.Parser;
+import seedu.address.logic.parser.Prefix;
+import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.person.FilterCriteria;
+import seedu.address.model.person.PersonPredicate;
+import seedu.address.model.person.Column;
+import seedu.address.model.person.Operator;
+
+/**
+ * Parses input arguments and creates a new FilterPersonCommand object.
+ */
+public class FilterPersonCommandParser implements Parser<FilterPersonCommand> {
+
+    private static final Pattern OPERATOR_FORMAT = Pattern.compile("^([a-zA-Z]+):");
+
+    private static final Pattern QUOTED_VALUE_PATTERN = Pattern.compile("\"([^\"]*)\"");
+
+    private Column getColumnFromPrefix(Prefix prefix) throws ParseException {
+        String prefixStr = prefix.getPrefix();
+
+        if (prefixStr.equals(PREFIX_NAME.getPrefix())) {
+            return Column.NAME;
+        } else if (prefixStr.equals(PREFIX_PHONE.getPrefix())) {
+            return Column.PHONE;
+        } else if (prefixStr.equals(PREFIX_EMAIL.getPrefix())) {
+            return Column.EMAIL;
+        } else if (prefixStr.equals(PREFIX_TAG.getPrefix())) {
+            return Column.TAG;
+        } else if (prefixStr.equals(PREFIX_COURSE.getPrefix())) {
+            return Column.COURSE;
+        } else if (prefixStr.equals(PREFIX_GROUP.getPrefix())) {
+            return Column.GROUP;
+        } else {
+            throw new ParseException(
+                    String.format(MESSAGE_UNRECOGNIZED_COLUMN, prefixStr)
+            );
+        }
+    }
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the FilterPersonCommand
+     * and returns a FilterPersonCommand object for execution.
+     * @throws ParseException if the user input does not conform to the expected format
+     */
+    public FilterPersonCommand parse(String args) throws ParseException {
+        if (args.trim().isEmpty()) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindPersonCommand.MESSAGE_USAGE));
+        }
+
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args,
+                PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ID, PREFIX_COURSE, PREFIX_GROUP, PREFIX_TAG);
+
+        Map<Column, FilterCriteria> filterCriteriaMap = new HashMap<>();
+
+        List<Prefix> allPrefixes = List.of(PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL,
+                PREFIX_ID, PREFIX_COURSE, PREFIX_GROUP, PREFIX_TAG);
+
+        for (Prefix prefix : allPrefixes) {
+            if (prefix.getPrefix().isEmpty()) {
+                continue;
+            }
+
+            List<String> rawValues = argMultimap.getAllValues(prefix);
+            if (rawValues.isEmpty()) {
+                continue;
+            }
+
+            try {
+                Column column = getColumnFromPrefix(prefix);
+
+                if (filterCriteriaMap.containsKey(column)) {
+                    throw new ParseException(MESSAGE_DUPLICATE_COLUMN);
+                }
+
+                String firstValue = rawValues.get(0);
+                Operator operator = Operator.AND; // Default operator
+                List<String> values = new ArrayList<>();
+
+                Matcher operatorMatcher = OPERATOR_FORMAT.matcher(firstValue);
+                if (operatorMatcher.find()) {
+                    String operatorStr = operatorMatcher.group(1);
+                    try {
+                        operator = Operator.valueOf(operatorStr.toUpperCase());
+                    } catch (IllegalArgumentException e) {
+                        throw new ParseException(
+                                String.format(MESSAGE_UNRECOGNIZED_OPERATOR, operatorStr)
+                        );
+                    }
+
+                    firstValue = firstValue.substring(operatorMatcher.end()).trim();
+                    if (!firstValue.isEmpty()) {
+                        values.addAll(extractValues(firstValue));
+                    }
+                } else {
+                    values.addAll(extractValues(firstValue));
+                }
+
+                for (int i = 1; i < rawValues.size(); i++) {
+                    values.addAll(extractValues(rawValues.get(i)));
+                }
+
+                if (values.isEmpty()) {
+                    throw new ParseException(
+                            String.format(MESSAGE_NO_VALUES, prefix.getPrefix())
+                    );
+                }
+
+                filterCriteriaMap.put(column, new FilterCriteria(operator, values));
+
+            } catch (IllegalArgumentException e) {
+                throw new ParseException(
+                        String.format(MESSAGE_UNRECOGNIZED_COLUMN, prefix.getPrefix())
+                );
+            }
+        }
+
+        if (filterCriteriaMap.isEmpty()) {
+            throw new ParseException(MESSAGE_NO_COLUMNS);
+        }
+
+        return new FilterPersonCommand(new PersonPredicate(filterCriteriaMap));
+    }
+
+    private List<String> extractValues(String input) {
+        List<String> values = new ArrayList<>();
+        Matcher quotedValueMatcher = QUOTED_VALUE_PATTERN.matcher(input);
+
+        int lastPosition = 0;
+
+        while (quotedValueMatcher.find()) {
+            values.add(quotedValueMatcher.group(1).trim());
+            lastPosition = quotedValueMatcher.end();
+        }
+
+        if (lastPosition > 0 && lastPosition < input.length()) {
+            String remaining = input.substring(lastPosition).trim();
+            if (!remaining.isEmpty()) {
+                // Split remaining text by whitespace
+                for (String value : remaining.split("\\s+")) {
+                    if (!value.trim().isEmpty()) {
+                        values.add(value.trim());
+                    }
+                }
+            }
+        }
+        else if (values.isEmpty() && !input.trim().isEmpty()) {
+            for (String value : input.trim().split("\\s+")) {
+                if (!value.trim().isEmpty()) {
+                    values.add(value.trim());
+                }
+            }
+        }
+
+        return values;
+    }
+}

--- a/src/main/java/seedu/address/model/person/Column.java
+++ b/src/main/java/seedu/address/model/person/Column.java
@@ -1,5 +1,9 @@
 package seedu.address.model.person;
 
+/**
+ * Represents the different columns or attributes of a Person that can be used for filtering.
+ * Each column has an associated abbreviation for easy reference.
+ */
 public enum Column {
     NAME("n"),
     PHONE("p"),
@@ -11,7 +15,21 @@ public enum Column {
 
     private final String abbrev;
 
+    /**
+     * Constructs a Column with the given abbreviation.
+     *
+     * @param abbrev the abbreviation for the column
+     */
     Column(String abbrev) {
         this.abbrev = abbrev;
+    }
+
+    /**
+     * Gets the abbreviation for this column.
+     *
+     * @return the abbreviation
+     */
+    public String getAbbrev() {
+        return abbrev;
     }
 }

--- a/src/main/java/seedu/address/model/person/Column.java
+++ b/src/main/java/seedu/address/model/person/Column.java
@@ -1,0 +1,17 @@
+package seedu.address.model.person;
+
+public enum Column {
+    NAME("n"),
+    PHONE("p"),
+    EMAIL("e"),
+    ID("i"),
+    COURSE("c"),
+    GROUP("g"),
+    TAG("t");
+
+    private final String abbrev;
+
+    Column(String abbrev) {
+        this.abbrev = abbrev;
+    }
+}

--- a/src/main/java/seedu/address/model/person/FilterCriteria.java
+++ b/src/main/java/seedu/address/model/person/FilterCriteria.java
@@ -4,20 +4,38 @@ import java.util.List;
 
 /**
  * Represents the filter criteria for a single column.
+ * Each criteria consists of a logical operator and a list of values to match against.
  */
 public class FilterCriteria {
     private final Operator operator;
+
     private final List<String> values;
 
+    /**
+     * Constructs a FilterCriteria with the given operator and values.
+     *
+     * @param operator the logical operator to apply
+     * @param values the list of values to match against
+     */
     public FilterCriteria(Operator operator, List<String> values) {
         this.operator = operator;
         this.values = values;
     }
 
+    /**
+     * Gets the logical operator for this criteria.
+     *
+     * @return the operator
+     */
     public Operator getOperator() {
         return operator;
     }
 
+    /**
+     * Gets the list of values for this criteria.
+     *
+     * @return the list of values
+     */
     public List<String> getValues() {
         return values;
     }
@@ -28,12 +46,19 @@ public class FilterCriteria {
             return true;
         }
 
-        if (!(other instanceof FilterCriteria)) {
+        if (!(other instanceof FilterCriteria otherCriteria)) {
             return false;
         }
 
-        FilterCriteria otherCriteria = (FilterCriteria) other;
         return operator == otherCriteria.operator
                 && values.equals(otherCriteria.values);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = 17;
+        result = 31 * result + operator.hashCode();
+        result = 31 * result + values.hashCode();
+        return result;
     }
 }

--- a/src/main/java/seedu/address/model/person/FilterCriteria.java
+++ b/src/main/java/seedu/address/model/person/FilterCriteria.java
@@ -1,0 +1,39 @@
+package seedu.address.model.person;
+
+import java.util.List;
+
+/**
+ * Represents the filter criteria for a single column.
+ */
+public class FilterCriteria {
+    private final Operator operator;
+    private final List<String> values;
+
+    public FilterCriteria(Operator operator, List<String> values) {
+        this.operator = operator;
+        this.values = values;
+    }
+
+    public Operator getOperator() {
+        return operator;
+    }
+
+    public List<String> getValues() {
+        return values;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        if (!(other instanceof FilterCriteria)) {
+            return false;
+        }
+
+        FilterCriteria otherCriteria = (FilterCriteria) other;
+        return operator == otherCriteria.operator
+                && values.equals(otherCriteria.values);
+    }
+}

--- a/src/main/java/seedu/address/model/person/Operator.java
+++ b/src/main/java/seedu/address/model/person/Operator.java
@@ -1,5 +1,9 @@
 package seedu.address.model.person;
 
+/**
+ * Represents the logical operators that can be used in filter criteria.
+ * These operators determine how multiple values in a filter criterion are combined.
+ */
 public enum Operator {
     AND("and"),
     OR("or"),
@@ -8,10 +12,20 @@ public enum Operator {
 
     private final String name;
 
+    /**
+     * Constructs an Operator with the given name.
+     *
+     * @param name the string representation of the operator
+     */
     Operator(String name) {
         this.name = name;
     }
 
+    /**
+     * Gets the name of this operator.
+     *
+     * @return the name of the operator
+     */
     public String getName() {
         return name;
     }

--- a/src/main/java/seedu/address/model/person/Operator.java
+++ b/src/main/java/seedu/address/model/person/Operator.java
@@ -1,0 +1,18 @@
+package seedu.address.model.person;
+
+public enum Operator {
+    AND("and"),
+    OR("or"),
+    NAND("nand"),
+    NOR("nor");
+
+    private final String name;
+
+    Operator(String name) {
+        this.name = name;
+    }
+
+    public String getName() {
+        return name;
+    }
+}

--- a/src/main/java/seedu/address/model/person/PersonPredicate.java
+++ b/src/main/java/seedu/address/model/person/PersonPredicate.java
@@ -86,14 +86,14 @@ public class PersonPredicate implements Predicate<Person> {
      */
     private boolean testCriteria(List<String> personValues, FilterCriteria criteria) {
         return switch (criteria.getOperator()) {
-            case AND -> criteria.getValues().stream().allMatch(value ->
-                    personValues.stream().anyMatch(pv -> pv.contains(value.toLowerCase())));
-            case OR -> criteria.getValues().stream().anyMatch(value ->
-                    personValues.stream().anyMatch(pv -> pv.contains(value.toLowerCase())));
-            case NAND -> !criteria.getValues().stream().allMatch(value ->
-                    personValues.stream().anyMatch(pv -> pv.contains(value.toLowerCase())));
-            case NOR -> criteria.getValues().stream().noneMatch(value ->
-                    personValues.stream().anyMatch(pv -> pv.contains(value.toLowerCase())));
+        case AND -> criteria.getValues().stream().allMatch(value ->
+                personValues.stream().anyMatch(pv -> pv.contains(value.toLowerCase())));
+        case OR -> criteria.getValues().stream().anyMatch(value ->
+                personValues.stream().anyMatch(pv -> pv.contains(value.toLowerCase())));
+        case NAND -> !criteria.getValues().stream().allMatch(value ->
+                personValues.stream().anyMatch(pv -> pv.contains(value.toLowerCase())));
+        case NOR -> criteria.getValues().stream().noneMatch(value ->
+                personValues.stream().anyMatch(pv -> pv.contains(value.toLowerCase())));
         };
     }
 

--- a/src/main/java/seedu/address/model/person/PersonPredicate.java
+++ b/src/main/java/seedu/address/model/person/PersonPredicate.java
@@ -6,7 +6,8 @@ import java.util.Map;
 import java.util.function.Predicate;
 
 /**
- * Represents a complex predicate for filtering Person objects.
+ * Represents a complex predicate for filtering Person objects based on multiple criteria.
+ * Each criterion consists of a column and associated filter conditions.
  */
 public class PersonPredicate implements Predicate<Person> {
 
@@ -14,6 +15,8 @@ public class PersonPredicate implements Predicate<Person> {
 
     /**
      * Constructs a PersonPredicate with the given filter criteria map.
+     *
+     * @param filterCriteriaMap map of columns to their filter criteria
      */
     public PersonPredicate(Map<Column, FilterCriteria> filterCriteriaMap) {
         this.filterCriteriaMap = filterCriteriaMap;
@@ -21,7 +24,6 @@ public class PersonPredicate implements Predicate<Person> {
 
     @Override
     public boolean test(Person person) {
-        // Test each filter criterion
         for (Map.Entry<Column, FilterCriteria> entry : filterCriteriaMap.entrySet()) {
             Column column = entry.getKey();
             FilterCriteria criteria = entry.getValue();
@@ -36,6 +38,13 @@ public class PersonPredicate implements Predicate<Person> {
         return true;
     }
 
+    /**
+     * Extracts values from a person based on the specified column.
+     *
+     * @param person the person to extract values from
+     * @param column the column to extract values for
+     * @return a list of values from the person for the specified column
+     */
     private List<String> getPersonValues(Person person, Column column) {
         List<String> values = new ArrayList<>();
         switch (column) {
@@ -62,10 +71,19 @@ public class PersonPredicate implements Predicate<Person> {
                     .map(tag -> tag.tagName.toLowerCase())
                     .toList());
             break;
+        default:
+            break;
         }
         return values;
     }
 
+    /**
+     * Tests if the person's values match the filter criteria.
+     *
+     * @param personValues the values from the person
+     * @param criteria the filter criteria to match against
+     * @return true if the values match the criteria, false otherwise
+     */
     private boolean testCriteria(List<String> personValues, FilterCriteria criteria) {
         return switch (criteria.getOperator()) {
             case AND -> criteria.getValues().stream().allMatch(value ->

--- a/src/main/java/seedu/address/model/person/PersonPredicate.java
+++ b/src/main/java/seedu/address/model/person/PersonPredicate.java
@@ -1,0 +1,95 @@
+package seedu.address.model.person;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Predicate;
+
+/**
+ * Represents a complex predicate for filtering Person objects.
+ */
+public class PersonPredicate implements Predicate<Person> {
+
+    private final Map<Column, FilterCriteria> filterCriteriaMap;
+
+    /**
+     * Constructs a PersonPredicate with the given filter criteria map.
+     */
+    public PersonPredicate(Map<Column, FilterCriteria> filterCriteriaMap) {
+        this.filterCriteriaMap = filterCriteriaMap;
+    }
+
+    @Override
+    public boolean test(Person person) {
+        // Test each filter criterion
+        for (Map.Entry<Column, FilterCriteria> entry : filterCriteriaMap.entrySet()) {
+            Column column = entry.getKey();
+            FilterCriteria criteria = entry.getValue();
+
+            List<String> personValues = getPersonValues(person, column);
+            boolean match = testCriteria(personValues, criteria);
+
+            if (!match) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private List<String> getPersonValues(Person person, Column column) {
+        List<String> values = new ArrayList<>();
+        switch (column) {
+        case NAME:
+            values.add(person.getName().fullName.toLowerCase());
+            break;
+        case PHONE:
+            values.add(person.getPhone().value.toLowerCase());
+            break;
+        case EMAIL:
+            values.add(person.getEmail().value.toLowerCase());
+            break;
+        case ID:
+            values.add(person.getId().fullId.toLowerCase());
+            break;
+        case COURSE:
+            values.add(person.getCourse().fullModule.toLowerCase());
+            break;
+        case GROUP:
+            values.add(person.getGroup().fullGroup.toLowerCase());
+            break;
+        case TAG:
+            values.addAll(person.getTags().stream()
+                    .map(tag -> tag.tagName.toLowerCase())
+                    .toList());
+            break;
+        }
+        return values;
+    }
+
+    private boolean testCriteria(List<String> personValues, FilterCriteria criteria) {
+        return switch (criteria.getOperator()) {
+            case AND -> criteria.getValues().stream().allMatch(value ->
+                    personValues.stream().anyMatch(pv -> pv.contains(value.toLowerCase())));
+            case OR -> criteria.getValues().stream().anyMatch(value ->
+                    personValues.stream().anyMatch(pv -> pv.contains(value.toLowerCase())));
+            case NAND -> !criteria.getValues().stream().allMatch(value ->
+                    personValues.stream().anyMatch(pv -> pv.contains(value.toLowerCase())));
+            case NOR -> criteria.getValues().stream().noneMatch(value ->
+                    personValues.stream().anyMatch(pv -> pv.contains(value.toLowerCase())));
+        };
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        if (!(other instanceof PersonPredicate)) {
+            return false;
+        }
+
+        PersonPredicate otherPredicate = (PersonPredicate) other;
+        return filterCriteriaMap.equals(otherPredicate.filterCriteriaMap);
+    }
+}

--- a/src/test/java/seedu/address/logic/commands/person/FilterPersonCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/person/FilterPersonCommandTest.java
@@ -1,0 +1,108 @@
+package seedu.address.logic.commands.person;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static seedu.address.logic.Messages.MESSAGE_PERSONS_LISTED_OVERVIEW;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.testutil.TypicalPersons.ALICE;
+import static seedu.address.testutil.TypicalPersons.CARL;
+import static seedu.address.testutil.TypicalPersons.DANIEL;
+import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+import seedu.address.model.event.EventManagerWithFilteredList;
+import seedu.address.model.person.Column;
+import seedu.address.model.person.FilterCriteria;
+import seedu.address.model.person.Operator;
+import seedu.address.model.person.PersonManagerWithFilteredList;
+import seedu.address.model.person.PersonPredicate;
+import seedu.address.model.todo.TodoManagerWithFilteredList;
+
+/**
+ * Contains integration tests (interaction with the Model) for {@code FilterPersonCommand}.
+ */
+public class FilterPersonCommandTest {
+    private final Model model = new ModelManager(
+            new UserPrefs(),
+            new PersonManagerWithFilteredList(getTypicalAddressBook()),
+            new TodoManagerWithFilteredList(),
+            new EventManagerWithFilteredList()
+    );
+    private final Model expectedModel = new ModelManager(
+            new UserPrefs(),
+            new PersonManagerWithFilteredList(getTypicalAddressBook()),
+            new TodoManagerWithFilteredList(),
+            new EventManagerWithFilteredList()
+    );
+
+    @Test
+    public void equals() {
+        Map<Column, FilterCriteria> firstPredicateMap = new HashMap<>();
+        Map<Column, FilterCriteria> secondPredicateMap = new HashMap<>();
+        firstPredicateMap.put(Column.NAME, new FilterCriteria(Operator.AND, Arrays.asList("first", "test")));
+        secondPredicateMap.put(Column.NAME, new FilterCriteria(Operator.OR, Arrays.asList("second", "test")));
+
+        PersonPredicate firstPredicate = new PersonPredicate(firstPredicateMap);
+        PersonPredicate secondPredicate = new PersonPredicate(secondPredicateMap);
+
+        FilterPersonCommand findFirstCommand = new FilterPersonCommand(firstPredicate);
+        FilterPersonCommand findSecondCommand = new FilterPersonCommand(secondPredicate);
+
+        // same object -> returns true
+        assertEquals(findFirstCommand, findFirstCommand);
+
+        // same values -> returns true
+        FilterPersonCommand findFirstCommandCopy = new FilterPersonCommand(firstPredicate);
+        assertEquals(findFirstCommand, findFirstCommandCopy);
+
+        // different types -> returns false
+        assertNotEquals(1, findFirstCommand);
+
+        // null -> returns false
+        assertNotEquals(null, findFirstCommand);
+
+        // different predicates -> returns false
+        assertNotEquals(findFirstCommand, findSecondCommand);
+    }
+
+    @Test
+    public void execute_nameFilter_multiplePersonsFound() {
+        Map<Column, FilterCriteria> predicateMap = new HashMap<>();
+        predicateMap.put(Column.NAME, new FilterCriteria(Operator.OR, Arrays.asList("Carl", "Daniel")));
+
+        PersonPredicate predicate = new PersonPredicate(predicateMap);
+        FilterPersonCommand command = new FilterPersonCommand(predicate);
+
+        expectedModel.getPersonManagerAndList().updateFilteredItemsList(predicate);
+        String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 2);
+
+        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+        assertEquals(Arrays.asList(CARL, DANIEL), model.getPersonManagerAndList().getFilteredItemsList());
+    }
+
+    @Test
+    public void execute_multipleFilters_matchingPersonFound() {
+        Map<Column, FilterCriteria> predicateMap = new HashMap<>();
+        predicateMap.put(Column.NAME, new FilterCriteria(Operator.AND, List.of("alice")));
+        predicateMap.put(Column.TAG, new FilterCriteria(Operator.AND, List.of("friends")));
+
+        PersonPredicate predicate = new PersonPredicate(predicateMap);
+        FilterPersonCommand command = new FilterPersonCommand(predicate);
+
+        expectedModel.getPersonManagerAndList().updateFilteredItemsList(predicate);
+        String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 1);
+
+        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+        assertEquals(Collections.singletonList(ALICE), model.getPersonManagerAndList().getFilteredItemsList());
+    }
+}

--- a/src/test/java/seedu/address/logic/parser/person/FilterPersonCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/person/FilterPersonCommandParserTest.java
@@ -9,6 +9,7 @@ import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSucces
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import org.junit.jupiter.api.Test;
@@ -22,7 +23,7 @@ import seedu.address.model.person.PersonPredicate;
 
 public class FilterPersonCommandParserTest {
 
-    private FilterPersonCommandParser parser = new FilterPersonCommandParser();
+    private final FilterPersonCommandParser parser = new FilterPersonCommandParser();
 
     @Test
     public void parse_emptyArg_throwsParseException() {
@@ -123,9 +124,9 @@ public class FilterPersonCommandParserTest {
     public void parse_multipleFilters_returnsFilterCommand() {
         // Test combining multiple filters with different operators
         Map<Column, FilterCriteria> expectedPredicateMap = new HashMap<>();
-        expectedPredicateMap.put(Column.NAME, new FilterCriteria(Operator.AND, Arrays.asList("alice")));
+        expectedPredicateMap.put(Column.NAME, new FilterCriteria(Operator.AND, List.of("alice")));
         expectedPredicateMap.put(Column.EMAIL, new FilterCriteria(Operator.OR, Arrays.asList("gmail", "yahoo")));
-        expectedPredicateMap.put(Column.TAG, new FilterCriteria(Operator.NAND, Arrays.asList("friend")));
+        expectedPredicateMap.put(Column.TAG, new FilterCriteria(Operator.NAND, List.of("friend")));
         PersonPredicate expectedPredicate = new PersonPredicate(expectedPredicateMap);
         FilterPersonCommand expectedFilterCommand = new FilterPersonCommand(expectedPredicate);
 

--- a/src/test/java/seedu/address/logic/parser/person/FilterPersonCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/person/FilterPersonCommandParserTest.java
@@ -1,7 +1,6 @@
 package seedu.address.logic.parser.person;
 
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-
 import static seedu.address.logic.Messages.MESSAGE_UNRECOGNIZED_OPERATOR;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
@@ -63,7 +62,8 @@ public class FilterPersonCommandParserTest {
     public void parse_quotedValues_returnsFilterCommand() {
         // Quote-wrapped values
         Map<Column, FilterCriteria> expectedPredicateMap = new HashMap<>();
-        expectedPredicateMap.put(Column.NAME, new FilterCriteria(Operator.AND, Collections.singletonList("alice pauline")));
+        expectedPredicateMap.put(Column.NAME, new FilterCriteria(Operator.AND,
+                Collections.singletonList("alice pauline")));
         PersonPredicate expectedPredicate = new PersonPredicate(expectedPredicateMap);
         FilterPersonCommand expectedFilterCommand = new FilterPersonCommand(expectedPredicate);
 

--- a/src/test/java/seedu/address/logic/parser/person/FilterPersonCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/person/FilterPersonCommandParserTest.java
@@ -1,0 +1,134 @@
+package seedu.address.logic.parser.person;
+
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
+import static seedu.address.logic.Messages.MESSAGE_UNRECOGNIZED_OPERATOR;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.commands.person.FilterPersonCommand;
+import seedu.address.logic.commands.person.FindPersonCommand;
+import seedu.address.model.person.Column;
+import seedu.address.model.person.FilterCriteria;
+import seedu.address.model.person.Operator;
+import seedu.address.model.person.PersonPredicate;
+
+public class FilterPersonCommandParserTest {
+
+    private FilterPersonCommandParser parser = new FilterPersonCommandParser();
+
+    @Test
+    public void parse_emptyArg_throwsParseException() {
+        assertParseFailure(parser, "     ",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindPersonCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_validArgs_returnsFilterCommand() {
+        // Single value with default AND operator
+        Map<Column, FilterCriteria> expectedPredicateMap = new HashMap<>();
+        expectedPredicateMap.put(Column.NAME, new FilterCriteria(Operator.AND, Collections.singletonList("alice")));
+        PersonPredicate expectedPredicate = new PersonPredicate(expectedPredicateMap);
+        FilterPersonCommand expectedFilterCommand = new FilterPersonCommand(expectedPredicate);
+
+        assertParseSuccess(parser, " n/alice", expectedFilterCommand);
+
+        // Multiple values with explicit OR operator
+        expectedPredicateMap.clear();
+        expectedPredicateMap.put(Column.NAME, new FilterCriteria(Operator.OR, Arrays.asList("alice", "bob")));
+        expectedPredicate = new PersonPredicate(expectedPredicateMap);
+        expectedFilterCommand = new FilterPersonCommand(expectedPredicate);
+
+        assertParseSuccess(parser, " n/or: alice bob", expectedFilterCommand);
+
+        // Multiple columns
+        expectedPredicateMap.clear();
+        expectedPredicateMap.put(Column.NAME, new FilterCriteria(Operator.AND, Collections.singletonList("alice")));
+        expectedPredicateMap.put(Column.EMAIL, new FilterCriteria(Operator.AND, Collections.singletonList("gmail")));
+        expectedPredicate = new PersonPredicate(expectedPredicateMap);
+        expectedFilterCommand = new FilterPersonCommand(expectedPredicate);
+
+        assertParseSuccess(parser, " n/alice e/gmail", expectedFilterCommand);
+    }
+
+    @Test
+    public void parse_quotedValues_returnsFilterCommand() {
+        // Quote-wrapped values
+        Map<Column, FilterCriteria> expectedPredicateMap = new HashMap<>();
+        expectedPredicateMap.put(Column.NAME, new FilterCriteria(Operator.AND, Collections.singletonList("alice pauline")));
+        PersonPredicate expectedPredicate = new PersonPredicate(expectedPredicateMap);
+        FilterPersonCommand expectedFilterCommand = new FilterPersonCommand(expectedPredicate);
+
+        assertParseSuccess(parser, " n/\"alice pauline\"", expectedFilterCommand);
+
+        // Mix of quoted and unquoted values
+        expectedPredicateMap.clear();
+        expectedPredicateMap.put(Column.NAME, new FilterCriteria(Operator.OR, Arrays.asList("alice pauline", "bob")));
+        expectedPredicate = new PersonPredicate(expectedPredicateMap);
+        expectedFilterCommand = new FilterPersonCommand(expectedPredicate);
+
+        assertParseSuccess(parser, " n/or: \"alice pauline\" bob", expectedFilterCommand);
+    }
+
+    @Test
+    public void parse_allOperators_returnsFilterCommand() {
+        // AND operator
+        Map<Column, FilterCriteria> expectedPredicateMap = new HashMap<>();
+        expectedPredicateMap.put(Column.NAME, new FilterCriteria(Operator.AND, Arrays.asList("alice", "pauline")));
+        PersonPredicate expectedPredicate = new PersonPredicate(expectedPredicateMap);
+        FilterPersonCommand expectedFilterCommand = new FilterPersonCommand(expectedPredicate);
+
+        assertParseSuccess(parser, " n/and: alice pauline", expectedFilterCommand);
+
+        // OR operator
+        expectedPredicateMap.clear();
+        expectedPredicateMap.put(Column.NAME, new FilterCriteria(Operator.OR, Arrays.asList("alice", "bob")));
+        expectedPredicate = new PersonPredicate(expectedPredicateMap);
+        expectedFilterCommand = new FilterPersonCommand(expectedPredicate);
+
+        assertParseSuccess(parser, " n/or: alice bob", expectedFilterCommand);
+
+        // NAND operator
+        expectedPredicateMap.clear();
+        expectedPredicateMap.put(Column.NAME, new FilterCriteria(Operator.NAND, Arrays.asList("alice", "bob")));
+        expectedPredicate = new PersonPredicate(expectedPredicateMap);
+        expectedFilterCommand = new FilterPersonCommand(expectedPredicate);
+
+        assertParseSuccess(parser, " n/nand: alice bob", expectedFilterCommand);
+
+        // NOR operator
+        expectedPredicateMap.clear();
+        expectedPredicateMap.put(Column.NAME, new FilterCriteria(Operator.NOR, Arrays.asList("alice", "bob")));
+        expectedPredicate = new PersonPredicate(expectedPredicateMap);
+        expectedFilterCommand = new FilterPersonCommand(expectedPredicate);
+
+        assertParseSuccess(parser, " n/nor: alice bob", expectedFilterCommand);
+    }
+
+    @Test
+    public void parse_invalidOperator_throwsParseException() {
+        assertParseFailure(parser, " n/invalid: alice",
+                String.format(MESSAGE_UNRECOGNIZED_OPERATOR, "invalid")
+        );
+    }
+
+    @Test
+    public void parse_multipleFilters_returnsFilterCommand() {
+        // Test combining multiple filters with different operators
+        Map<Column, FilterCriteria> expectedPredicateMap = new HashMap<>();
+        expectedPredicateMap.put(Column.NAME, new FilterCriteria(Operator.AND, Arrays.asList("alice")));
+        expectedPredicateMap.put(Column.EMAIL, new FilterCriteria(Operator.OR, Arrays.asList("gmail", "yahoo")));
+        expectedPredicateMap.put(Column.TAG, new FilterCriteria(Operator.NAND, Arrays.asList("friend")));
+        PersonPredicate expectedPredicate = new PersonPredicate(expectedPredicateMap);
+        FilterPersonCommand expectedFilterCommand = new FilterPersonCommand(expectedPredicate);
+
+        assertParseSuccess(parser, " n/alice e/or: gmail yahoo t/nand: friend", expectedFilterCommand);
+    }
+}

--- a/src/test/java/seedu/address/model/person/PersonPredicateTest.java
+++ b/src/test/java/seedu/address/model/person/PersonPredicateTest.java
@@ -10,6 +10,7 @@ import static seedu.address.testutil.TypicalPersons.BENSON;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import org.junit.jupiter.api.Test;
@@ -87,7 +88,7 @@ public class PersonPredicateTest {
 
         // NAND operator
         predicateMap.clear();
-        predicateMap.put(Column.NAME, new FilterCriteria(Operator.NAND, Arrays.asList("Alice")));
+        predicateMap.put(Column.NAME, new FilterCriteria(Operator.NAND, List.of("Alice")));
         predicate = new PersonPredicate(predicateMap);
         assertFalse(predicate.test(ALICE)); // Alice contains Alice, so NAND fails
 

--- a/src/test/java/seedu/address/model/person/PersonPredicateTest.java
+++ b/src/test/java/seedu/address/model/person/PersonPredicateTest.java
@@ -1,0 +1,134 @@
+package seedu.address.model.person;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.testutil.TypicalPersons.ALICE;
+import static seedu.address.testutil.TypicalPersons.BENSON;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+public class PersonPredicateTest {
+
+    @Test
+    public void equals() {
+        Map<Column, FilterCriteria> firstPredicateMap = new HashMap<>();
+        firstPredicateMap.put(Column.NAME, new FilterCriteria(Operator.AND, Collections.singletonList("Alice")));
+
+        Map<Column, FilterCriteria> secondPredicateMap = new HashMap<>();
+        secondPredicateMap.put(Column.EMAIL, new FilterCriteria(Operator.OR, Collections.singletonList("gmail.com")));
+
+        PersonPredicate firstPredicate = new PersonPredicate(firstPredicateMap);
+        PersonPredicate secondPredicate = new PersonPredicate(secondPredicateMap);
+
+        // same object -> returns true
+        assertEquals(firstPredicate, firstPredicate);
+
+        // same values -> returns true
+        PersonPredicate firstPredicateCopy = new PersonPredicate(firstPredicateMap);
+        assertEquals(firstPredicate, firstPredicateCopy);
+
+        // different types -> returns false
+        assertNotEquals(1, firstPredicate);
+
+        // null -> returns false
+        assertNotEquals(null, firstPredicate);
+
+        // different predicate -> returns false
+        assertNotEquals(firstPredicate, secondPredicate);
+    }
+
+    @Test
+    public void test_nameContainsKeywords_returnsTrue() {
+        // AND operator - all keywords must match
+        Map<Column, FilterCriteria> predicateMap = new HashMap<>();
+        predicateMap.put(Column.NAME, new FilterCriteria(Operator.AND, Arrays.asList("Alice", "Pauline")));
+        PersonPredicate predicate = new PersonPredicate(predicateMap);
+        assertTrue(predicate.test(ALICE)); // Alice Pauline matches
+
+        // OR operator - at least one keyword must match
+        predicateMap.clear();
+        predicateMap.put(Column.NAME, new FilterCriteria(Operator.OR, Arrays.asList("Alice", "Bob")));
+        predicate = new PersonPredicate(predicateMap);
+        assertTrue(predicate.test(ALICE)); // Alice matches
+
+        // NAND operator - at least one keyword must not match
+        predicateMap.clear();
+        predicateMap.put(Column.NAME, new FilterCriteria(Operator.NAND, Arrays.asList("Bob", "Charlie")));
+        predicate = new PersonPredicate(predicateMap);
+        assertTrue(predicate.test(ALICE)); // Alice doesn't contain Bob or Charlie
+
+        // NOR operator - all keywords must not match
+        predicateMap.clear();
+        predicateMap.put(Column.NAME, new FilterCriteria(Operator.NOR, Arrays.asList("Bob", "Charlie")));
+        predicate = new PersonPredicate(predicateMap);
+        assertTrue(predicate.test(ALICE)); // Alice doesn't contain Bob or Charlie
+    }
+
+    @Test
+    public void test_nameDoesNotContainKeywords_returnsFalse() {
+        // AND operator
+        Map<Column, FilterCriteria> predicateMap = new HashMap<>();
+        predicateMap.put(Column.NAME, new FilterCriteria(Operator.AND, Arrays.asList("Alice", "Bob")));
+        PersonPredicate predicate = new PersonPredicate(predicateMap);
+        assertFalse(predicate.test(BENSON)); // Benson doesn't contain Alice and Bob
+
+        // OR operator
+        predicateMap.clear();
+        predicateMap.put(Column.NAME, new FilterCriteria(Operator.OR, Arrays.asList("Charlie", "David")));
+        predicate = new PersonPredicate(predicateMap);
+        assertFalse(predicate.test(ALICE)); // Alice doesn't contain Charlie or David
+
+        // NAND operator
+        predicateMap.clear();
+        predicateMap.put(Column.NAME, new FilterCriteria(Operator.NAND, Arrays.asList("Alice")));
+        predicate = new PersonPredicate(predicateMap);
+        assertFalse(predicate.test(ALICE)); // Alice contains Alice, so NAND fails
+
+        // NOR operator
+        predicateMap.clear();
+        predicateMap.put(Column.NAME, new FilterCriteria(Operator.NOR, Arrays.asList("Alice", "Bob")));
+        predicate = new PersonPredicate(predicateMap);
+        assertFalse(predicate.test(ALICE)); // Alice contains Alice, so NOR fails
+    }
+
+    @Test
+    public void test_multipleColumns_matchesAccordingly() {
+        // Test multiple columns with AND relationship (implicit between columns)
+        Map<Column, FilterCriteria> predicateMap = new HashMap<>();
+        predicateMap.put(Column.NAME, new FilterCriteria(Operator.AND, Collections.singletonList("Alice")));
+        predicateMap.put(Column.EMAIL, new FilterCriteria(Operator.AND, Collections.singletonList("example")));
+
+        PersonPredicate predicate = new PersonPredicate(predicateMap);
+        assertTrue(predicate.test(ALICE)); // Alice has both Alice in name and example in email
+        assertFalse(predicate.test(BENSON)); // Benson doesn't have Alice in name
+    }
+
+    @Test
+    public void test_differentFields_returnsCorrectResults() {
+        // Test ID field
+        Map<Column, FilterCriteria> predicateMap = new HashMap<>();
+        predicateMap.put(Column.ID, new FilterCriteria(Operator.AND, Collections.singletonList(ALICE.getId().fullId)));
+        PersonPredicate predicate = new PersonPredicate(predicateMap);
+        assertTrue(predicate.test(ALICE));
+
+        // Test PHONE field
+        predicateMap.clear();
+        predicateMap.put(Column.PHONE, new FilterCriteria(Operator.AND, Collections.singletonList(ALICE.getPhone().value)));
+        predicate = new PersonPredicate(predicateMap);
+        assertTrue(predicate.test(ALICE));
+
+        // Test TAG field
+        predicateMap.clear();
+        String tag = ALICE.getTags().stream().findFirst().get().tagName;
+        predicateMap.put(Column.TAG, new FilterCriteria(Operator.AND, Collections.singletonList(tag)));
+        predicate = new PersonPredicate(predicateMap);
+        assertTrue(predicate.test(ALICE));
+    }
+}

--- a/src/test/java/seedu/address/model/person/PersonPredicateTest.java
+++ b/src/test/java/seedu/address/model/person/PersonPredicateTest.java
@@ -121,7 +121,8 @@ public class PersonPredicateTest {
 
         // Test PHONE field
         predicateMap.clear();
-        predicateMap.put(Column.PHONE, new FilterCriteria(Operator.AND, Collections.singletonList(ALICE.getPhone().value)));
+        predicateMap.put(Column.PHONE, new FilterCriteria(Operator.AND,
+                Collections.singletonList(ALICE.getPhone().value)));
         predicate = new PersonPredicate(predicateMap);
         assertTrue(predicate.test(ALICE));
 


### PR DESCRIPTION
Add support for all `filter <col>/ [<op>:] <value(s)> [...]` commands for every contact related prefix (`n/`, `p/`, ...) and operations (`and:`, `or:`, `nand:`, `nor:`)

General idea is that filtering logic is built around `FilterCriteria` which specifies the operation and value to filter against. This is used to generate `PersonPredicate` used to update `filteredItemLists` model similar to existing `find`. 

Initial argument parsing is performed using `ArgumentMap`. However, processing of each argument is performed using rather hardcoded regex since there's a mixture of spaced fields (delimited by quotations) and unspaced fields and operators. 
- [ ] Can consider building or updating `ArgumentMap` functionality to support processing operations and filter values
- [ ] add support for `'` quotations
- [x] add support for `"` quotations

Fixes #64 