### PR TITLE
[#155] Add tests for todo command parsers

### DIFF
--- a/src/main/java/seedu/address/commons/util/DatetimeUtil.java
+++ b/src/main/java/seedu/address/commons/util/DatetimeUtil.java
@@ -1,0 +1,31 @@
+package seedu.address.commons.util;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+
+/**
+ * A container for datetime utilities.
+ */
+public class DatetimeUtil {
+    public static final DateTimeFormatter DATE_TIME_FORMATTER =
+            DateTimeFormatter.ofPattern("yy-MM-dd HH:mm");
+
+    /**
+     * Parse a datetime string.
+     */
+    public static LocalDateTime parse(String string) {
+        try {
+            LocalDateTime datetime = LocalDateTime.parse(string, DATE_TIME_FORMATTER);
+
+            String formattedDatetime = datetime.format(DATE_TIME_FORMATTER);
+            if (string.equals(formattedDatetime)) {
+                return datetime;
+            } else {
+                throw new IllegalArgumentException("Invalid datetime: " + string);
+            }
+        } catch (DateTimeParseException e) {
+            throw new IllegalArgumentException("Invalid datetime: " + string);
+        }
+    }
+}

--- a/src/main/java/seedu/address/logic/commands/todo/AddPersonToTodoCommand.java
+++ b/src/main/java/seedu/address/logic/commands/todo/AddPersonToTodoCommand.java
@@ -9,6 +9,7 @@ import java.util.function.Function;
 import java.util.stream.Stream;
 
 import seedu.address.commons.core.index.Index;
+import seedu.address.commons.util.ToStringBuilder;
 import seedu.address.logic.Messages;
 import seedu.address.logic.TodoMessages;
 import seedu.address.logic.abstractcommand.EditCommand;
@@ -97,5 +98,28 @@ public class AddPersonToTodoCommand extends EditCommand<Todo> {
     @Override
     public String getSuccessMessage(Todo editedItem) {
         return String.format(MESSAGE_ADD_PERSON_SUCCESS, Messages.format(editedItem));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof AddPersonToTodoCommand otherCommand)) {
+            return false;
+        }
+
+        return index.equals(otherCommand.index)
+                && personIndices.equals(otherCommand.personIndices);
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this)
+                .add("index", index)
+                .add("personIndicies", personIndices)
+                .toString();
     }
 }

--- a/src/main/java/seedu/address/logic/commands/todo/AddTodoCommand.java
+++ b/src/main/java/seedu/address/logic/commands/todo/AddTodoCommand.java
@@ -6,6 +6,7 @@ import static seedu.address.logic.parser.todo.TodoCliSyntax.PREFIX_TODO_DEADLINE
 import static seedu.address.logic.parser.todo.TodoCliSyntax.PREFIX_TODO_LOCATION;
 import static seedu.address.logic.parser.todo.TodoCliSyntax.PREFIX_TODO_NAME;
 
+import seedu.address.commons.util.ToStringBuilder;
 import seedu.address.logic.Messages;
 import seedu.address.logic.abstractcommand.AddCommand;
 import seedu.address.model.Model;
@@ -46,5 +47,26 @@ public class AddTodoCommand extends AddCommand<Todo> {
     @Override
     public String getSuccessMessage(Todo todo) {
         return String.format(MESSAGE_SUCCESS, Messages.format(todo));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof AddTodoCommand otherAddTodoCommand)) {
+            return false;
+        }
+
+        return itemToAdd.equals(otherAddTodoCommand.itemToAdd);
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this)
+                .add("toAdd", itemToAdd)
+                .toString();
     }
 }

--- a/src/main/java/seedu/address/logic/commands/todo/DeleteTodoCommand.java
+++ b/src/main/java/seedu/address/logic/commands/todo/DeleteTodoCommand.java
@@ -4,6 +4,7 @@ import static seedu.address.logic.TodoMessages.MESSAGE_INVALID_TODO_DISPLAYED_IN
 import static seedu.address.logic.parser.CliSyntax.TODO_COMMAND_WORD;
 
 import seedu.address.commons.core.index.Index;
+import seedu.address.commons.util.ToStringBuilder;
 import seedu.address.logic.Messages;
 import seedu.address.logic.abstractcommand.DeleteCommand;
 import seedu.address.model.Model;
@@ -41,5 +42,26 @@ public class DeleteTodoCommand extends DeleteCommand<Todo> {
     @Override
     public String getSuccessMessage(Todo todo) {
         return String.format(MESSAGE_DELETE_TODO_SUCCESS, Messages.format(todo));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof DeleteTodoCommand otherDeleteCommand)) {
+            return false;
+        }
+
+        return targetIndex.equals(otherDeleteCommand.targetIndex);
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this)
+                .add("targetIndex", targetIndex)
+                .toString();
     }
 }

--- a/src/main/java/seedu/address/logic/commands/todo/DisplayTodoInformationCommand.java
+++ b/src/main/java/seedu/address/logic/commands/todo/DisplayTodoInformationCommand.java
@@ -4,6 +4,7 @@ import static seedu.address.logic.TodoMessages.MESSAGE_INVALID_TODO_DISPLAYED_IN
 import static seedu.address.logic.parser.CliSyntax.TODO_COMMAND_WORD;
 
 import seedu.address.commons.core.index.Index;
+import seedu.address.commons.util.ToStringBuilder;
 import seedu.address.logic.Messages;
 import seedu.address.logic.abstractcommand.DisplayInformationCommand;
 import seedu.address.model.Model;
@@ -27,6 +28,7 @@ public class DisplayTodoInformationCommand extends DisplayInformationCommand<Tod
     /**
      * Creates a {@code DisplayTodoInformationCommand} to display information of the {@code Todo} at
      * the specified {@code index}.
+     *
      * @throws NullPointerException if {@code index} is {@code null}.
      */
     public DisplayTodoInformationCommand(Index index) {
@@ -41,5 +43,26 @@ public class DisplayTodoInformationCommand extends DisplayInformationCommand<Tod
     @Override
     public String getInformationMessage(Todo itemToDisplay) {
         return String.format(MESSAGE_DISPLAY_INFO, Messages.format(itemToDisplay));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof DisplayTodoInformationCommand otherCommand)) {
+            return false;
+        }
+
+        return index.equals(otherCommand.index);
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this)
+                .add("index", index)
+                .toString();
     }
 }

--- a/src/main/java/seedu/address/logic/commands/todo/MarkTodoAsDoneCommand.java
+++ b/src/main/java/seedu/address/logic/commands/todo/MarkTodoAsDoneCommand.java
@@ -3,6 +3,7 @@ package seedu.address.logic.commands.todo;
 import static seedu.address.logic.parser.CliSyntax.TODO_COMMAND_WORD;
 
 import seedu.address.commons.core.index.Index;
+import seedu.address.commons.util.ToStringBuilder;
 import seedu.address.logic.Messages;
 import seedu.address.logic.TodoMessages;
 import seedu.address.logic.abstractcommand.EditCommand;
@@ -64,5 +65,26 @@ public class MarkTodoAsDoneCommand extends EditCommand<Todo> {
     @Override
     public String getSuccessMessage(Todo todo) {
         return String.format(MESSAGE_TODO_MARKED_DONE, Messages.format(todo));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof MarkTodoAsDoneCommand otherCommand)) {
+            return false;
+        }
+
+        return index.equals(otherCommand.index);
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this)
+                .add("index", index)
+                .toString();
     }
 }

--- a/src/main/java/seedu/address/logic/commands/todo/MarkTodoAsNotDoneCommand.java
+++ b/src/main/java/seedu/address/logic/commands/todo/MarkTodoAsNotDoneCommand.java
@@ -3,6 +3,7 @@ package seedu.address.logic.commands.todo;
 import static seedu.address.logic.parser.CliSyntax.TODO_COMMAND_WORD;
 
 import seedu.address.commons.core.index.Index;
+import seedu.address.commons.util.ToStringBuilder;
 import seedu.address.logic.Messages;
 import seedu.address.logic.TodoMessages;
 import seedu.address.logic.abstractcommand.EditCommand;
@@ -65,5 +66,26 @@ public class MarkTodoAsNotDoneCommand extends EditCommand<Todo> {
     @Override
     public String getSuccessMessage(Todo todo) {
         return String.format(MESSAGE_TODO_MARKED_NOT_DONE, Messages.format(todo));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof MarkTodoAsNotDoneCommand otherCommand)) {
+            return false;
+        }
+
+        return index.equals(otherCommand.index);
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this)
+                .add("index", index)
+                .toString();
     }
 }

--- a/src/main/java/seedu/address/logic/commands/todo/RemovePersonFromTodoCommand.java
+++ b/src/main/java/seedu/address/logic/commands/todo/RemovePersonFromTodoCommand.java
@@ -9,6 +9,7 @@ import java.util.Comparator;
 import java.util.List;
 
 import seedu.address.commons.core.index.Index;
+import seedu.address.commons.util.ToStringBuilder;
 import seedu.address.logic.Messages;
 import seedu.address.logic.TodoMessages;
 import seedu.address.logic.abstractcommand.EditCommand;
@@ -83,5 +84,28 @@ public class RemovePersonFromTodoCommand extends EditCommand<Todo> {
     @Override
     public String getSuccessMessage(Todo editedItem) {
         return String.format(MESSAGE_REMOVE_PERSON_SUCCESS, Messages.format(editedItem));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof RemovePersonFromTodoCommand otherCommand)) {
+            return false;
+        }
+
+        return index.equals(otherCommand.index)
+                && personIndices.equals(otherCommand.personIndices);
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this)
+                .add("index", index)
+                .add("personIndicies", personIndices)
+                .toString();
     }
 }

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -14,7 +14,8 @@ import seedu.address.logic.parser.exceptions.ParseException;
  */
 public class ParserUtil {
 
-    public static final String MESSAGE_INVALID_INDEX = "Index is not a non-zero unsigned integer.";
+    public static final String MESSAGE_INVALID_INDEX =
+            "Index is not a non-zero unsigned integer: %1$s";
     public static final String MESSAGE_DUPLICATE_INDEX = "Duplicate index found: %1$s";
 
     /**
@@ -26,7 +27,7 @@ public class ParserUtil {
     public static Index parseIndex(String oneBasedIndex) throws ParseException {
         String trimmedIndex = oneBasedIndex.trim();
         if (!StringUtil.isNonZeroUnsignedInteger(trimmedIndex)) {
-            throw new ParseException(MESSAGE_INVALID_INDEX);
+            throw new ParseException(String.format(MESSAGE_INVALID_INDEX, trimmedIndex));
         }
         return Index.fromOneBased(Integer.parseInt(trimmedIndex));
     }
@@ -47,7 +48,7 @@ public class ParserUtil {
 
         for (String strIndex : indices) {
             if (!StringUtil.isNonZeroUnsignedInteger(strIndex)) {
-                throw new ParseException(MESSAGE_INVALID_INDEX);
+                throw new ParseException(String.format(MESSAGE_INVALID_INDEX, strIndex));
             }
 
             Index index = Index.fromOneBased(Integer.parseInt(strIndex));

--- a/src/main/java/seedu/address/logic/parser/person/AddPersonCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/person/AddPersonCommandParser.java
@@ -48,13 +48,13 @@ public class AddPersonCommandParser implements Parser<AddPersonCommand> {
 
         argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_PERSON_ID, PREFIX_PERSON_NAME, PREFIX_PERSON_PHONE,
                 PREFIX_PERSON_EMAIL, PREFIX_PERSON_COURSE, PREFIX_PERSON_GROUP);
-        Id id = PersonParseUtil.parseId(argMultimap.getValue(PREFIX_PERSON_ID).get());
-        Name name = PersonParseUtil.parseName(argMultimap.getValue(PREFIX_PERSON_NAME).get());
-        Phone phone = PersonParseUtil.parsePhone(argMultimap.getValue(PREFIX_PERSON_PHONE).get());
-        Email email = PersonParseUtil.parseEmail(argMultimap.getValue(PREFIX_PERSON_EMAIL).get());
-        Course course = PersonParseUtil.parseModule(argMultimap.getValue(PREFIX_PERSON_COURSE).get());
-        Group group = PersonParseUtil.parseGroup(argMultimap.getValue(PREFIX_PERSON_GROUP).get());
-        Set<Tag> tagList = PersonParseUtil.parseTags(argMultimap.getAllValues(PREFIX_PERSON_TAG));
+        Id id = PersonParserUtil.parseId(argMultimap.getValue(PREFIX_PERSON_ID).get());
+        Name name = PersonParserUtil.parseName(argMultimap.getValue(PREFIX_PERSON_NAME).get());
+        Phone phone = PersonParserUtil.parsePhone(argMultimap.getValue(PREFIX_PERSON_PHONE).get());
+        Email email = PersonParserUtil.parseEmail(argMultimap.getValue(PREFIX_PERSON_EMAIL).get());
+        Course course = PersonParserUtil.parseModule(argMultimap.getValue(PREFIX_PERSON_COURSE).get());
+        Group group = PersonParserUtil.parseGroup(argMultimap.getValue(PREFIX_PERSON_GROUP).get());
+        Set<Tag> tagList = PersonParserUtil.parseTags(argMultimap.getAllValues(PREFIX_PERSON_TAG));
 
         Person person = new Person(id, name, phone, email, course, group, tagList);
         return new AddPersonCommand(person);

--- a/src/main/java/seedu/address/logic/parser/person/EditPersonCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/person/EditPersonCommandParser.java
@@ -56,23 +56,23 @@ public class EditPersonCommandParser implements Parser<EditPersonCommand> {
         EditPersonDescriptor editPersonDescriptor = new EditPersonDescriptor();
 
         if (argMultimap.getValue(PREFIX_PERSON_ID).isPresent()) {
-            editPersonDescriptor.setId(PersonParseUtil.parseId(argMultimap.getValue(PREFIX_PERSON_ID).get()));
+            editPersonDescriptor.setId(PersonParserUtil.parseId(argMultimap.getValue(PREFIX_PERSON_ID).get()));
         }
         if (argMultimap.getValue(PREFIX_PERSON_NAME).isPresent()) {
-            editPersonDescriptor.setName(PersonParseUtil.parseName(argMultimap.getValue(PREFIX_PERSON_NAME).get()));
+            editPersonDescriptor.setName(PersonParserUtil.parseName(argMultimap.getValue(PREFIX_PERSON_NAME).get()));
         }
         if (argMultimap.getValue(PREFIX_PERSON_PHONE).isPresent()) {
-            editPersonDescriptor.setPhone(PersonParseUtil.parsePhone(argMultimap.getValue(PREFIX_PERSON_PHONE).get()));
+            editPersonDescriptor.setPhone(PersonParserUtil.parsePhone(argMultimap.getValue(PREFIX_PERSON_PHONE).get()));
         }
         if (argMultimap.getValue(PREFIX_PERSON_EMAIL).isPresent()) {
-            editPersonDescriptor.setEmail(PersonParseUtil.parseEmail(argMultimap.getValue(PREFIX_PERSON_EMAIL).get()));
+            editPersonDescriptor.setEmail(PersonParserUtil.parseEmail(argMultimap.getValue(PREFIX_PERSON_EMAIL).get()));
         }
         if (argMultimap.getValue(PREFIX_PERSON_COURSE).isPresent()) {
-            editPersonDescriptor.setCourse(PersonParseUtil
+            editPersonDescriptor.setCourse(PersonParserUtil
                     .parseModule(argMultimap.getValue(PREFIX_PERSON_COURSE).get()));
         }
         if (argMultimap.getValue(PREFIX_PERSON_GROUP).isPresent()) {
-            editPersonDescriptor.setGroup(PersonParseUtil.parseGroup(argMultimap.getValue(PREFIX_PERSON_GROUP).get()));
+            editPersonDescriptor.setGroup(PersonParserUtil.parseGroup(argMultimap.getValue(PREFIX_PERSON_GROUP).get()));
         }
         parseTagsForEdit(argMultimap.getAllValues(PREFIX_PERSON_TAG)).ifPresent(editPersonDescriptor::setTags);
 
@@ -96,7 +96,7 @@ public class EditPersonCommandParser implements Parser<EditPersonCommand> {
         }
         Collection<String> tagSet = tags.size() == 1 && tags.contains("") ? Collections.emptySet()
                 : tags;
-        return Optional.of(PersonParseUtil.parseTags(tagSet));
+        return Optional.of(PersonParserUtil.parseTags(tagSet));
     }
 
 }

--- a/src/main/java/seedu/address/logic/parser/person/PersonParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/person/PersonParserUtil.java
@@ -18,7 +18,7 @@ import seedu.address.model.person.Tag;
 /**
  * Contains utility methods used for parsing strings in the various *Parser classes.
  */
-public class PersonParseUtil {
+public class PersonParserUtil {
 
     /**
      * Parses a {@code String id} into an {@code Id}.

--- a/src/main/java/seedu/address/logic/parser/todo/AddPersonToTodoCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/todo/AddPersonToTodoCommandParser.java
@@ -37,15 +37,7 @@ public class AddPersonToTodoCommandParser implements Parser<AddPersonToTodoComma
                     AddPersonToTodoCommand.MESSAGE_USAGE));
         }
 
-        Index index;
-
-        try {
-            index = ParserUtil.parseIndex(argMultimap.getPreamble());
-        } catch (ParseException pe) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
-                    AddPersonToTodoCommand.MESSAGE_USAGE), pe);
-        }
-
+        Index index = ParserUtil.parseIndex(argMultimap.getPreamble());
         argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_LINKED_PERSON_INDEX);
         List<Index> personIndices =
                 ParserUtil.parseIndices(argMultimap.getValue(PREFIX_LINKED_PERSON_INDEX).get());

--- a/src/main/java/seedu/address/logic/parser/todo/AddTodoCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/todo/AddTodoCommandParser.java
@@ -37,11 +37,11 @@ public class AddTodoCommandParser implements Parser<AddTodoCommand> {
 
         argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_TODO_NAME, PREFIX_TODO_DEADLINE,
                 PREFIX_TODO_LOCATION);
-        TodoName name = TodoParseUtil.parseName(argMultimap.getValue(PREFIX_TODO_NAME).get());
+        TodoName name = TodoParserUtil.parseName(argMultimap.getValue(PREFIX_TODO_NAME).get());
         TodoDeadline deadline =
-                TodoParseUtil.parseDeadline(argMultimap.getValue(PREFIX_TODO_DEADLINE).get());
+                TodoParserUtil.parseDeadline(argMultimap.getValue(PREFIX_TODO_DEADLINE).get());
         TodoLocation location =
-                TodoParseUtil.parseLocation(argMultimap.getValue(PREFIX_TODO_LOCATION).get());
+                TodoParserUtil.parseLocation(argMultimap.getValue(PREFIX_TODO_LOCATION).get());
 
         Todo todo = new Todo(name, deadline, location);
 

--- a/src/main/java/seedu/address/logic/parser/todo/DeleteTodoCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/todo/DeleteTodoCommandParser.java
@@ -1,7 +1,5 @@
 package seedu.address.logic.parser.todo;
 
-import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.todo.DeleteTodoCommand;
 import seedu.address.logic.parser.Parser;
@@ -20,13 +18,8 @@ public class DeleteTodoCommandParser implements Parser<DeleteTodoCommand> {
      * @throws ParseException if the user input does not conform the expected format
      */
     public DeleteTodoCommand parse(String args) throws ParseException {
-        try {
-            Index index = ParserUtil.parseIndex(args);
-            return new DeleteTodoCommand(index);
-        } catch (ParseException pe) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
-                    DeleteTodoCommand.MESSAGE_USAGE), pe);
-        }
+        Index index = ParserUtil.parseIndex(args);
+        return new DeleteTodoCommand(index);
     }
 
 }

--- a/src/main/java/seedu/address/logic/parser/todo/DisplayTodoInfoCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/todo/DisplayTodoInfoCommandParser.java
@@ -1,7 +1,5 @@
 package seedu.address.logic.parser.todo;
 
-import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.todo.DisplayTodoInformationCommand;
 import seedu.address.logic.parser.Parser;
@@ -20,12 +18,7 @@ public class DisplayTodoInfoCommandParser implements Parser<DisplayTodoInformati
      * @throws ParseException if the user input does not conform the expected format
      */
     public DisplayTodoInformationCommand parse(String args) throws ParseException {
-        try {
-            Index index = ParserUtil.parseIndex(args);
-            return new DisplayTodoInformationCommand(index);
-        } catch (ParseException pe) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
-                    DisplayTodoInformationCommand.MESSAGE_USAGE), pe);
-        }
+        Index index = ParserUtil.parseIndex(args);
+        return new DisplayTodoInformationCommand(index);
     }
 }

--- a/src/main/java/seedu/address/logic/parser/todo/MarkTodoAsDoneCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/todo/MarkTodoAsDoneCommandParser.java
@@ -1,7 +1,5 @@
 package seedu.address.logic.parser.todo;
 
-import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.todo.MarkTodoAsDoneCommand;
 import seedu.address.logic.parser.Parser;
@@ -20,13 +18,8 @@ public class MarkTodoAsDoneCommandParser implements Parser<MarkTodoAsDoneCommand
      * @throws ParseException if the user input does not conform the expected format
      */
     public MarkTodoAsDoneCommand parse(String args) throws ParseException {
-        try {
-            Index index = ParserUtil.parseIndex(args);
-            return new MarkTodoAsDoneCommand(index);
-        } catch (ParseException pe) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
-                    MarkTodoAsDoneCommand.MESSAGE_USAGE), pe);
-        }
+        Index index = ParserUtil.parseIndex(args);
+        return new MarkTodoAsDoneCommand(index);
     }
 
 }

--- a/src/main/java/seedu/address/logic/parser/todo/MarkTodoAsNotDoneCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/todo/MarkTodoAsNotDoneCommandParser.java
@@ -1,7 +1,5 @@
 package seedu.address.logic.parser.todo;
 
-import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.todo.MarkTodoAsNotDoneCommand;
 import seedu.address.logic.parser.Parser;
@@ -20,13 +18,8 @@ public class MarkTodoAsNotDoneCommandParser implements Parser<MarkTodoAsNotDoneC
      * @throws ParseException if the user input does not conform the expected format
      */
     public MarkTodoAsNotDoneCommand parse(String args) throws ParseException {
-        try {
-            Index index = ParserUtil.parseIndex(args);
-            return new MarkTodoAsNotDoneCommand(index);
-        } catch (ParseException pe) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
-                    MarkTodoAsNotDoneCommand.MESSAGE_USAGE), pe);
-        }
+        Index index = ParserUtil.parseIndex(args);
+        return new MarkTodoAsNotDoneCommand(index);
     }
 
 }

--- a/src/main/java/seedu/address/logic/parser/todo/RemovePersonFromTodoCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/todo/RemovePersonFromTodoCommandParser.java
@@ -31,15 +31,13 @@ public class RemovePersonFromTodoCommandParser implements Parser<RemovePersonFro
         requireNonNull(args);
         ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_LINKED_PERSON_INDEX);
 
-        Index index;
-
-        try {
-            index = ParserUtil.parseIndex(argMultimap.getPreamble());
-        } catch (ParseException pe) {
+        if (!argMultimap.arePrefixesPresent(PREFIX_LINKED_PERSON_INDEX)
+                || argMultimap.getPreamble().isEmpty()) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
-                    RemovePersonFromTodoCommand.MESSAGE_USAGE), pe);
+                    RemovePersonFromTodoCommand.MESSAGE_USAGE));
         }
 
+        Index index = ParserUtil.parseIndex(argMultimap.getPreamble());
         argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_LINKED_PERSON_INDEX);
         List<Index> personIndices =
                 ParserUtil.parseIndices(argMultimap.getValue(PREFIX_LINKED_PERSON_INDEX).get());

--- a/src/main/java/seedu/address/logic/parser/todo/TodoParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/todo/TodoParserUtil.java
@@ -10,7 +10,7 @@ import seedu.address.model.todo.TodoName;
 /**
  * Contains utility methods used for parsing strings in the various classes parsing todo commands.
  */
-public class TodoParseUtil {
+public class TodoParserUtil {
     /**
      * Parses a {@code String name} into a {@code TodoName}. Leading and trailing whitespaces will
      * be trimmed.

--- a/src/main/java/seedu/address/model/event/EventDateTime.java
+++ b/src/main/java/seedu/address/model/event/EventDateTime.java
@@ -5,7 +5,6 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
 import static seedu.address.commons.util.DatetimeUtil.DATE_TIME_FORMATTER;
 
 import java.time.LocalDateTime;
-import java.time.format.DateTimeParseException;
 
 import seedu.address.commons.util.DatetimeUtil;
 

--- a/src/main/java/seedu/address/model/event/EventDateTime.java
+++ b/src/main/java/seedu/address/model/event/EventDateTime.java
@@ -2,10 +2,12 @@ package seedu.address.model.event;
 
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.AppUtil.checkArgument;
+import static seedu.address.commons.util.DatetimeUtil.DATE_TIME_FORMATTER;
 
 import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
+
+import seedu.address.commons.util.DatetimeUtil;
 
 /**
  * Represents an Event's date and time.
@@ -16,7 +18,6 @@ public class EventDateTime {
             "Event start/end time should be in the format YY-MM-DD HH:MM, where HH is in 24-hour format.";
     public static final String MESSAGE_NEGATIVE_DURATION =
             "The given event start-time is not before the given end-time.";
-    public static final DateTimeFormatter DATE_TIME_FORMATTER = DateTimeFormatter.ofPattern("yy-MM-dd HH:mm");
     public final LocalDateTime dateTime;
 
     /**
@@ -27,7 +28,7 @@ public class EventDateTime {
     public EventDateTime(String dateTime) {
         requireNonNull(dateTime);
         checkArgument(isValid(dateTime), MESSAGE_CONSTRAINTS);
-        this.dateTime = LocalDateTime.parse(dateTime, DATE_TIME_FORMATTER);
+        this.dateTime = DatetimeUtil.parse(dateTime);
     }
 
     /**
@@ -35,9 +36,9 @@ public class EventDateTime {
      */
     public static boolean isValid(String dateTime) {
         try {
-            LocalDateTime.parse(dateTime, DATE_TIME_FORMATTER);
+            DatetimeUtil.parse(dateTime);
             return true;
-        } catch (DateTimeParseException e) {
+        } catch (IllegalArgumentException e) {
             return false;
         }
     }

--- a/src/main/java/seedu/address/model/todo/TodoDeadline.java
+++ b/src/main/java/seedu/address/model/todo/TodoDeadline.java
@@ -2,10 +2,12 @@ package seedu.address.model.todo;
 
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.AppUtil.checkArgument;
+import static seedu.address.commons.util.DatetimeUtil.DATE_TIME_FORMATTER;
 
 import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
+
+import seedu.address.commons.util.DatetimeUtil;
 
 /**
  * Represents a Todo's deadline.
@@ -15,9 +17,6 @@ public class TodoDeadline {
 
     public static final String MESSAGE_CONSTRAINTS =
             "Deadline should be in the format YY-MM-DD HH:MM, where HH is in 24-hour format.";
-
-    public static final DateTimeFormatter DATE_TIME_FORMATTER =
-            DateTimeFormatter.ofPattern("yy-MM-dd HH:mm");
 
     public final LocalDateTime deadline;
 
@@ -29,7 +28,7 @@ public class TodoDeadline {
     public TodoDeadline(String deadline) {
         requireNonNull(deadline);
         checkArgument(isValid(deadline), MESSAGE_CONSTRAINTS);
-        this.deadline = LocalDateTime.parse(deadline, DATE_TIME_FORMATTER);
+        this.deadline = DatetimeUtil.parse(deadline);
     }
 
     /**
@@ -37,9 +36,9 @@ public class TodoDeadline {
      */
     public static boolean isValid(String test) {
         try {
-            LocalDateTime.parse(test, DATE_TIME_FORMATTER);
+            DatetimeUtil.parse(test);
             return true;
-        } catch (DateTimeParseException e) {
+        } catch (IllegalArgumentException e) {
             return false;
         }
     }

--- a/src/main/java/seedu/address/model/todo/TodoDeadline.java
+++ b/src/main/java/seedu/address/model/todo/TodoDeadline.java
@@ -5,7 +5,6 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
 import static seedu.address.commons.util.DatetimeUtil.DATE_TIME_FORMATTER;
 
 import java.time.LocalDateTime;
-import java.time.format.DateTimeParseException;
 
 import seedu.address.commons.util.DatetimeUtil;
 

--- a/src/test/java/seedu/address/logic/commands/TodoCommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/TodoCommandTestUtil.java
@@ -1,0 +1,34 @@
+package seedu.address.logic.commands;
+
+import static seedu.address.logic.parser.todo.TodoCliSyntax.PREFIX_TODO_DEADLINE;
+import static seedu.address.logic.parser.todo.TodoCliSyntax.PREFIX_TODO_LOCATION;
+import static seedu.address.logic.parser.todo.TodoCliSyntax.PREFIX_TODO_NAME;
+
+/**
+ * Contains helper methods for testing todo commands.
+ */
+public class TodoCommandTestUtil {
+    public static final String VALID_NAME_REPORT = "Report";
+    public static final String VALID_NAME_GRADING = "Grading submissions";
+    public static final String VALID_DEADLINE_REPORT = "25-12-31 23:59";
+    public static final String VALID_DEADLINE_GRADING = "25-11-30 23:59";
+    public static final String VALID_LOCATION_REPORT = "Canvas";
+    public static final String VALID_LOCATION_GRADING = "Prof office";
+
+    public static final String NAME_DESC_REPORT = " " + PREFIX_TODO_NAME + VALID_NAME_REPORT;
+    public static final String NAME_DESC_GRADING = " " + PREFIX_TODO_NAME + VALID_NAME_GRADING;
+    public static final String DEADLINE_DESC_REPORT =
+            " " + PREFIX_TODO_DEADLINE + VALID_DEADLINE_REPORT;
+    public static final String DEADLINE_DESC_GRADING =
+            " " + PREFIX_TODO_DEADLINE + VALID_DEADLINE_GRADING;
+    public static final String LOCATION_DESC_REPORT =
+            " " + PREFIX_TODO_LOCATION + VALID_LOCATION_REPORT;
+    public static final String LOCATION_DESC_GRADING =
+            " " + PREFIX_TODO_LOCATION + VALID_LOCATION_GRADING;
+
+    public static final String INVALID_TODO_NAME_DESC = " " + PREFIX_TODO_NAME + "Stuff&stuff";
+    public static final String INVALID_TODO_DEADLINE_DESC_NOT_DATETIME =
+            " " + PREFIX_TODO_DEADLINE + "aaaa";
+    public static final String INVALID_TODO_DEADLINE_DESC_INCORRECT_FORMAT =
+            " " + PREFIX_TODO_DEADLINE + "23:59 25-12-31";
+}

--- a/src/test/java/seedu/address/logic/commands/person/DeletePersonCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/person/DeletePersonCommandTest.java
@@ -6,8 +6,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.logic.commands.CommandTestUtil.showPersonAtIndex;
-import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
-import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST;
+import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND;
 import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
 
 import org.junit.jupiter.api.Test;
@@ -41,8 +41,8 @@ public class DeletePersonCommandTest {
     @Test
     public void execute_validIndexUnfilteredList_success() {
         Person personToDelete = model.getPersonManagerAndList().getFilteredItemsList()
-                .get(INDEX_FIRST_PERSON.getZeroBased());
-        DeletePersonCommand deleteCommand = new DeletePersonCommand(INDEX_FIRST_PERSON);
+                .get(INDEX_FIRST.getZeroBased());
+        DeletePersonCommand deleteCommand = new DeletePersonCommand(INDEX_FIRST);
 
         String expectedMessage = String.format(DeletePersonCommand.MESSAGE_DELETE_PERSON_SUCCESS,
                 Messages.format(personToDelete));
@@ -75,11 +75,11 @@ public class DeletePersonCommandTest {
 
     @Test
     public void execute_validIndexFilteredList_success() {
-        showPersonAtIndex(model, INDEX_FIRST_PERSON);
+        showPersonAtIndex(model, INDEX_FIRST);
 
         Person personToDelete = model.getPersonManagerAndList().getFilteredItemsList()
-                .get(INDEX_FIRST_PERSON.getZeroBased());
-        DeletePersonCommand deleteCommand = new DeletePersonCommand(INDEX_FIRST_PERSON);
+                .get(INDEX_FIRST.getZeroBased());
+        DeletePersonCommand deleteCommand = new DeletePersonCommand(INDEX_FIRST);
 
         String expectedMessage = String.format(DeletePersonCommand.MESSAGE_DELETE_PERSON_SUCCESS,
                 Messages.format(personToDelete));
@@ -104,9 +104,9 @@ public class DeletePersonCommandTest {
 
     @Test
     public void execute_invalidIndexFilteredList_throwsCommandException() {
-        showPersonAtIndex(model, INDEX_FIRST_PERSON);
+        showPersonAtIndex(model, INDEX_FIRST);
 
-        Index outOfBoundIndex = INDEX_SECOND_PERSON;
+        Index outOfBoundIndex = INDEX_SECOND;
         // ensures that outOfBoundIndex is still in bounds of address book list
         assertTrue(outOfBoundIndex.getZeroBased() < model.getPersonManagerAndList().getItemManager()
                 .getItemList().size());
@@ -118,14 +118,14 @@ public class DeletePersonCommandTest {
 
     @Test
     public void equals() {
-        DeletePersonCommand deleteFirstCommand = new DeletePersonCommand(INDEX_FIRST_PERSON);
-        DeletePersonCommand deleteSecondCommand = new DeletePersonCommand(INDEX_SECOND_PERSON);
+        DeletePersonCommand deleteFirstCommand = new DeletePersonCommand(INDEX_FIRST);
+        DeletePersonCommand deleteSecondCommand = new DeletePersonCommand(INDEX_SECOND);
 
         // same object -> returns true
         assertTrue(deleteFirstCommand.equals(deleteFirstCommand));
 
         // same values -> returns true
-        DeletePersonCommand deleteFirstCommandCopy = new DeletePersonCommand(INDEX_FIRST_PERSON);
+        DeletePersonCommand deleteFirstCommandCopy = new DeletePersonCommand(INDEX_FIRST);
         assertTrue(deleteFirstCommand.equals(deleteFirstCommandCopy));
 
         // different types -> returns false

--- a/src/test/java/seedu/address/logic/commands/person/EditPersonCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/person/EditPersonCommandTest.java
@@ -11,8 +11,8 @@ import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.logic.commands.CommandTestUtil.showPersonAtIndex;
-import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
-import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST;
+import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND;
 import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
 
 import org.junit.jupiter.api.Test;
@@ -49,7 +49,7 @@ public class EditPersonCommandTest {
     public void execute_allFieldsSpecifiedUnfilteredList_success() {
         Person editedPerson = new PersonBuilder().build();
         EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder(editedPerson).build();
-        EditPersonCommand editCommand = new EditPersonCommand(INDEX_FIRST_PERSON, descriptor);
+        EditPersonCommand editCommand = new EditPersonCommand(INDEX_FIRST, descriptor);
 
         String expectedMessage = String.format(EditPersonCommand.MESSAGE_EDIT_PERSON_SUCCESS,
                 Messages.format(editedPerson));
@@ -110,10 +110,10 @@ public class EditPersonCommandTest {
 
     @Test
     public void execute_noFieldSpecifiedUnfilteredList_success() {
-        EditPersonCommand editCommand = new EditPersonCommand(INDEX_FIRST_PERSON,
+        EditPersonCommand editCommand = new EditPersonCommand(INDEX_FIRST,
                 new EditPersonDescriptor());
         Person editedPerson = model.getPersonManagerAndList().getFilteredItemsList()
-                .get(INDEX_FIRST_PERSON.getZeroBased());
+                .get(INDEX_FIRST.getZeroBased());
 
         String expectedMessage = String.format(EditPersonCommand.MESSAGE_EDIT_PERSON_SUCCESS,
                 Messages.format(editedPerson));
@@ -136,12 +136,12 @@ public class EditPersonCommandTest {
 
     @Test
     public void execute_filteredList_success() {
-        showPersonAtIndex(model, INDEX_FIRST_PERSON);
+        showPersonAtIndex(model, INDEX_FIRST);
 
         Person personInFilteredList = model.getPersonManagerAndList().getFilteredItemsList()
-                .get(INDEX_FIRST_PERSON.getZeroBased());
+                .get(INDEX_FIRST.getZeroBased());
         Person editedPerson = new PersonBuilder(personInFilteredList).withName(VALID_NAME_BOB).build();
-        EditPersonCommand editCommand = new EditPersonCommand(INDEX_FIRST_PERSON,
+        EditPersonCommand editCommand = new EditPersonCommand(INDEX_FIRST,
                 new EditPersonDescriptorBuilder().withName(VALID_NAME_BOB).build());
 
         String expectedMessage = String.format(EditPersonCommand.MESSAGE_EDIT_PERSON_SUCCESS,
@@ -168,21 +168,21 @@ public class EditPersonCommandTest {
     @Test
     public void execute_duplicatePersonUnfilteredList_failure() {
         Person firstPerson = model.getPersonManagerAndList()
-                .getFilteredItemsList().get(INDEX_FIRST_PERSON.getZeroBased());
+                .getFilteredItemsList().get(INDEX_FIRST.getZeroBased());
         EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder(firstPerson).build();
-        EditPersonCommand editCommand = new EditPersonCommand(INDEX_SECOND_PERSON, descriptor);
+        EditPersonCommand editCommand = new EditPersonCommand(INDEX_SECOND, descriptor);
 
         assertCommandFailure(editCommand, model, EditPersonCommand.MESSAGE_DUPLICATE_PERSON);
     }
 
     @Test
     public void execute_duplicatePersonFilteredList_failure() {
-        showPersonAtIndex(model, INDEX_FIRST_PERSON);
+        showPersonAtIndex(model, INDEX_FIRST);
 
         // edit person in filtered list into a duplicate in address book
         Person personInList = model.getPersonManagerAndList().getItemManager().getItemList()
-                .get(INDEX_SECOND_PERSON.getZeroBased());
-        EditPersonCommand editCommand = new EditPersonCommand(INDEX_FIRST_PERSON,
+                .get(INDEX_SECOND.getZeroBased());
+        EditPersonCommand editCommand = new EditPersonCommand(INDEX_FIRST,
                 new EditPersonDescriptorBuilder(personInList).build());
 
         assertCommandFailure(editCommand, model, EditPersonCommand.MESSAGE_DUPLICATE_PERSON);
@@ -204,8 +204,8 @@ public class EditPersonCommandTest {
      */
     @Test
     public void execute_invalidPersonIndexFilteredList_failure() {
-        showPersonAtIndex(model, INDEX_FIRST_PERSON);
-        Index outOfBoundIndex = INDEX_SECOND_PERSON;
+        showPersonAtIndex(model, INDEX_FIRST);
+        Index outOfBoundIndex = INDEX_SECOND;
         // ensures that outOfBoundIndex is still in bounds of address book list
         assertTrue(outOfBoundIndex.getZeroBased() < model.getPersonManagerAndList().getItemManager()
                 .getItemList().size());
@@ -218,11 +218,11 @@ public class EditPersonCommandTest {
 
     @Test
     public void equals() {
-        final EditPersonCommand standardCommand = new EditPersonCommand(INDEX_FIRST_PERSON, DESC_AMY);
+        final EditPersonCommand standardCommand = new EditPersonCommand(INDEX_FIRST, DESC_AMY);
 
         // same values -> returns true
         EditPersonDescriptor copyDescriptor = new EditPersonDescriptor(DESC_AMY);
-        EditPersonCommand commandWithSameValues = new EditPersonCommand(INDEX_FIRST_PERSON, copyDescriptor);
+        EditPersonCommand commandWithSameValues = new EditPersonCommand(INDEX_FIRST, copyDescriptor);
         assertTrue(standardCommand.equals(commandWithSameValues));
 
         // same object -> returns true
@@ -235,10 +235,10 @@ public class EditPersonCommandTest {
         assertFalse(standardCommand.equals(new ClearPersonCommand()));
 
         // different index -> returns false
-        assertFalse(standardCommand.equals(new EditPersonCommand(INDEX_SECOND_PERSON, DESC_AMY)));
+        assertFalse(standardCommand.equals(new EditPersonCommand(INDEX_SECOND, DESC_AMY)));
 
         // different descriptor -> returns false
-        assertFalse(standardCommand.equals(new EditPersonCommand(INDEX_FIRST_PERSON, DESC_BOB)));
+        assertFalse(standardCommand.equals(new EditPersonCommand(INDEX_FIRST, DESC_BOB)));
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/commands/person/InfoPersonCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/person/InfoPersonCommandTest.java
@@ -7,8 +7,8 @@ import static seedu.address.logic.Messages.MESSAGE_DISPLAY_SPECIFIC_PERSON_INFO;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.logic.commands.CommandTestUtil.showPersonAtIndex;
-import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
-import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST;
+import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND;
 import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
 
 import org.junit.jupiter.api.Test;
@@ -43,8 +43,8 @@ public class InfoPersonCommandTest {
     @Test
     public void execute_validIndexUnfilteredList_success() {
         Person personToShow =
-                model.getPersonManagerAndList().getFilteredItemsList().get(INDEX_FIRST_PERSON.getZeroBased());
-        InfoPersonCommand infoCommand = new InfoPersonCommand(INDEX_FIRST_PERSON);
+                model.getPersonManagerAndList().getFilteredItemsList().get(INDEX_FIRST.getZeroBased());
+        InfoPersonCommand infoCommand = new InfoPersonCommand(INDEX_FIRST);
 
         String expectedMessage = String.format(MESSAGE_DISPLAY_SPECIFIC_PERSON_INFO,
                 personToShow.getName());
@@ -61,11 +61,11 @@ public class InfoPersonCommandTest {
 
     @Test
     public void execute_validIndexFilteredList_success() {
-        showPersonAtIndex(model, INDEX_FIRST_PERSON);
-        showPersonAtIndex(expectedModel, INDEX_FIRST_PERSON);
+        showPersonAtIndex(model, INDEX_FIRST);
+        showPersonAtIndex(expectedModel, INDEX_FIRST);
         Person personToShow = model.getPersonManagerAndList()
-                .getFilteredItemsList().get(INDEX_FIRST_PERSON.getZeroBased());
-        InfoPersonCommand infoCommand = new InfoPersonCommand(INDEX_FIRST_PERSON);
+                .getFilteredItemsList().get(INDEX_FIRST.getZeroBased());
+        InfoPersonCommand infoCommand = new InfoPersonCommand(INDEX_FIRST);
         String expectedMessage = String.format(MESSAGE_DISPLAY_SPECIFIC_PERSON_INFO,
                 personToShow.getName());
         assertCommandSuccess(infoCommand, model, expectedMessage, expectedModel);
@@ -73,8 +73,8 @@ public class InfoPersonCommandTest {
 
     @Test
     public void execute_invalidIndexFilteredList_throwsCommandException() {
-        showPersonAtIndex(model, INDEX_FIRST_PERSON);
-        Index outOfBoundIndex = INDEX_SECOND_PERSON;
+        showPersonAtIndex(model, INDEX_FIRST);
+        Index outOfBoundIndex = INDEX_SECOND;
         assertTrue(outOfBoundIndex.getZeroBased() < model.getPersonManagerAndList().getItemManager()
                 .getItemList().size());
         InfoPersonCommand infoCommand = new InfoPersonCommand(outOfBoundIndex);
@@ -83,14 +83,14 @@ public class InfoPersonCommandTest {
 
     @Test
     public void equals() {
-        InfoPersonCommand showFirstCommand = new InfoPersonCommand(INDEX_FIRST_PERSON);
-        InfoPersonCommand showSecondCommand = new InfoPersonCommand(INDEX_SECOND_PERSON);
+        InfoPersonCommand showFirstCommand = new InfoPersonCommand(INDEX_FIRST);
+        InfoPersonCommand showSecondCommand = new InfoPersonCommand(INDEX_SECOND);
 
         // same object -> returns true
         assertTrue(showFirstCommand.equals(showFirstCommand));
 
         // same values -> returns true
-        InfoPersonCommand showFirstCommandCopy = new InfoPersonCommand(INDEX_FIRST_PERSON);
+        InfoPersonCommand showFirstCommandCopy = new InfoPersonCommand(INDEX_FIRST);
         assertTrue(showFirstCommand.equals(showFirstCommandCopy));
 
         // different types -> returns false
@@ -105,9 +105,9 @@ public class InfoPersonCommandTest {
 
     @Test
     public void toStringMethod() {
-        InfoPersonCommand infoCommand = new InfoPersonCommand(INDEX_FIRST_PERSON);
+        InfoPersonCommand infoCommand = new InfoPersonCommand(INDEX_FIRST);
         String expected =
-                InfoPersonCommand.class.getCanonicalName() + "{targetIndex=" + INDEX_FIRST_PERSON + "}";
+                InfoPersonCommand.class.getCanonicalName() + "{targetIndex=" + INDEX_FIRST + "}";
         assertEquals(expected, infoCommand.toString());
     }
 }

--- a/src/test/java/seedu/address/logic/commands/person/ListPersonCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/person/ListPersonCommandTest.java
@@ -2,7 +2,7 @@ package seedu.address.logic.commands.person;
 
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.logic.commands.CommandTestUtil.showPersonAtIndex;
-import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST;
 import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -47,7 +47,7 @@ public class ListPersonCommandTest {
 
     @Test
     public void execute_listIsFiltered_showsEverything() {
-        showPersonAtIndex(model, INDEX_FIRST_PERSON);
+        showPersonAtIndex(model, INDEX_FIRST);
         assertCommandSuccess(new ListPersonCommand(), model, ListPersonCommand.MESSAGE_SUCCESS,
                 expectedModel);
     }

--- a/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
@@ -4,7 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.parser.ParserUtil.MESSAGE_INVALID_INDEX;
 import static seedu.address.testutil.Assert.assertThrows;
-import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -14,7 +14,7 @@ import java.util.Set;
 import org.junit.jupiter.api.Test;
 
 import seedu.address.logic.parser.exceptions.ParseException;
-import seedu.address.logic.parser.person.PersonParseUtil;
+import seedu.address.logic.parser.person.PersonParserUtil;
 import seedu.address.model.person.Email;
 import seedu.address.model.person.Name;
 import seedu.address.model.person.Phone;
@@ -48,122 +48,122 @@ public class ParserUtilTest {
     @Test
     public void parseIndex_validInput_success() throws Exception {
         // No whitespaces
-        assertEquals(INDEX_FIRST_PERSON, ParserUtil.parseIndex("1"));
+        assertEquals(INDEX_FIRST, ParserUtil.parseIndex("1"));
 
         // Leading and trailing whitespaces
-        assertEquals(INDEX_FIRST_PERSON, ParserUtil.parseIndex("  1  "));
+        assertEquals(INDEX_FIRST, ParserUtil.parseIndex("  1  "));
     }
 
     @Test
     public void parseName_null_throwsNullPointerException() {
-        assertThrows(NullPointerException.class, () -> PersonParseUtil.parseName((String) null));
+        assertThrows(NullPointerException.class, () -> PersonParserUtil.parseName((String) null));
     }
 
     @Test
     public void parseName_invalidValue_throwsParseException() {
-        assertThrows(ParseException.class, () -> PersonParseUtil.parseName(INVALID_NAME));
+        assertThrows(ParseException.class, () -> PersonParserUtil.parseName(INVALID_NAME));
     }
 
     @Test
     public void parseName_validValueWithoutWhitespace_returnsName() throws Exception {
         Name expectedName = new Name(VALID_NAME);
-        assertEquals(expectedName, PersonParseUtil.parseName(VALID_NAME));
+        assertEquals(expectedName, PersonParserUtil.parseName(VALID_NAME));
     }
 
     @Test
     public void parseName_validValueWithWhitespace_returnsTrimmedName() throws Exception {
         String nameWithWhitespace = WHITESPACE + VALID_NAME + WHITESPACE;
         Name expectedName = new Name(VALID_NAME);
-        assertEquals(expectedName, PersonParseUtil.parseName(nameWithWhitespace));
+        assertEquals(expectedName, PersonParserUtil.parseName(nameWithWhitespace));
     }
 
     @Test
     public void parsePhone_null_throwsNullPointerException() {
-        assertThrows(NullPointerException.class, () -> PersonParseUtil.parsePhone((String) null));
+        assertThrows(NullPointerException.class, () -> PersonParserUtil.parsePhone((String) null));
     }
 
     @Test
     public void parsePhone_invalidValue_throwsParseException() {
-        assertThrows(ParseException.class, () -> PersonParseUtil.parsePhone(INVALID_PHONE));
+        assertThrows(ParseException.class, () -> PersonParserUtil.parsePhone(INVALID_PHONE));
     }
 
     @Test
     public void parsePhone_validValueWithoutWhitespace_returnsPhone() throws Exception {
         Phone expectedPhone = new Phone(VALID_PHONE);
-        assertEquals(expectedPhone, PersonParseUtil.parsePhone(VALID_PHONE));
+        assertEquals(expectedPhone, PersonParserUtil.parsePhone(VALID_PHONE));
     }
 
     @Test
     public void parsePhone_validValueWithWhitespace_returnsTrimmedPhone() throws Exception {
         String phoneWithWhitespace = WHITESPACE + VALID_PHONE + WHITESPACE;
         Phone expectedPhone = new Phone(VALID_PHONE);
-        assertEquals(expectedPhone, PersonParseUtil.parsePhone(phoneWithWhitespace));
+        assertEquals(expectedPhone, PersonParserUtil.parsePhone(phoneWithWhitespace));
     }
 
     @Test
     public void parseEmail_null_throwsNullPointerException() {
-        assertThrows(NullPointerException.class, () -> PersonParseUtil.parseEmail((String) null));
+        assertThrows(NullPointerException.class, () -> PersonParserUtil.parseEmail((String) null));
     }
 
     @Test
     public void parseEmail_invalidValue_throwsParseException() {
-        assertThrows(ParseException.class, () -> PersonParseUtil.parseEmail(INVALID_EMAIL));
+        assertThrows(ParseException.class, () -> PersonParserUtil.parseEmail(INVALID_EMAIL));
     }
 
     @Test
     public void parseEmail_validValueWithoutWhitespace_returnsEmail() throws Exception {
         Email expectedEmail = new Email(VALID_EMAIL);
-        assertEquals(expectedEmail, PersonParseUtil.parseEmail(VALID_EMAIL));
+        assertEquals(expectedEmail, PersonParserUtil.parseEmail(VALID_EMAIL));
     }
 
     @Test
     public void parseEmail_validValueWithWhitespace_returnsTrimmedEmail() throws Exception {
         String emailWithWhitespace = WHITESPACE + VALID_EMAIL + WHITESPACE;
         Email expectedEmail = new Email(VALID_EMAIL);
-        assertEquals(expectedEmail, PersonParseUtil.parseEmail(emailWithWhitespace));
+        assertEquals(expectedEmail, PersonParserUtil.parseEmail(emailWithWhitespace));
     }
 
     @Test
     public void parseTag_null_throwsNullPointerException() {
-        assertThrows(NullPointerException.class, () -> PersonParseUtil.parseTag(null));
+        assertThrows(NullPointerException.class, () -> PersonParserUtil.parseTag(null));
     }
 
     @Test
     public void parseTag_invalidValue_throwsParseException() {
-        assertThrows(ParseException.class, () -> PersonParseUtil.parseTag(INVALID_TAG));
+        assertThrows(ParseException.class, () -> PersonParserUtil.parseTag(INVALID_TAG));
     }
 
     @Test
     public void parseTag_validValueWithoutWhitespace_returnsTag() throws Exception {
         Tag expectedTag = new Tag(VALID_TAG_1);
-        assertEquals(expectedTag, PersonParseUtil.parseTag(VALID_TAG_1));
+        assertEquals(expectedTag, PersonParserUtil.parseTag(VALID_TAG_1));
     }
 
     @Test
     public void parseTag_validValueWithWhitespace_returnsTrimmedTag() throws Exception {
         String tagWithWhitespace = WHITESPACE + VALID_TAG_1 + WHITESPACE;
         Tag expectedTag = new Tag(VALID_TAG_1);
-        assertEquals(expectedTag, PersonParseUtil.parseTag(tagWithWhitespace));
+        assertEquals(expectedTag, PersonParserUtil.parseTag(tagWithWhitespace));
     }
 
     @Test
     public void parseTags_null_throwsNullPointerException() {
-        assertThrows(NullPointerException.class, () -> PersonParseUtil.parseTags(null));
+        assertThrows(NullPointerException.class, () -> PersonParserUtil.parseTags(null));
     }
 
     @Test
     public void parseTags_collectionWithInvalidTags_throwsParseException() {
-        assertThrows(ParseException.class, () -> PersonParseUtil.parseTags(Arrays.asList(VALID_TAG_1, INVALID_TAG)));
+        assertThrows(ParseException.class, () -> PersonParserUtil.parseTags(Arrays.asList(VALID_TAG_1, INVALID_TAG)));
     }
 
     @Test
     public void parseTags_emptyCollection_returnsEmptySet() throws Exception {
-        assertTrue(PersonParseUtil.parseTags(Collections.emptyList()).isEmpty());
+        assertTrue(PersonParserUtil.parseTags(Collections.emptyList()).isEmpty());
     }
 
     @Test
     public void parseTags_collectionWithValidTags_returnsTagSet() throws Exception {
-        Set<Tag> actualTagSet = PersonParseUtil.parseTags(Arrays.asList(VALID_TAG_1, VALID_TAG_2));
+        Set<Tag> actualTagSet = PersonParserUtil.parseTags(Arrays.asList(VALID_TAG_1, VALID_TAG_2));
         Set<Tag> expectedTagSet = new HashSet<Tag>(Arrays.asList(new Tag(VALID_TAG_1), new Tag(VALID_TAG_2)));
 
         assertEquals(expectedTagSet, actualTagSet);

--- a/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
@@ -41,8 +41,9 @@ public class ParserUtilTest {
 
     @Test
     public void parseIndex_outOfRangeInput_throwsParseException() {
-        assertThrows(ParseException.class, MESSAGE_INVALID_INDEX, ()
-            -> ParserUtil.parseIndex(Long.toString(Integer.MAX_VALUE + 1)));
+        assertThrows(ParseException.class,
+                String.format(MESSAGE_INVALID_INDEX, Long.toString(Integer.MAX_VALUE + 1)), ()
+                        -> ParserUtil.parseIndex(Long.toString(Integer.MAX_VALUE + 1)));
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/person/DeletePersonCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/person/DeletePersonCommandParserTest.java
@@ -3,7 +3,7 @@ package seedu.address.logic.parser.person;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
-import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST;
 
 import org.junit.jupiter.api.Test;
 
@@ -22,7 +22,7 @@ public class DeletePersonCommandParserTest {
 
     @Test
     public void parse_validArgs_returnsDeleteCommand() {
-        assertParseSuccess(parser, "1", new DeletePersonCommand(INDEX_FIRST_PERSON));
+        assertParseSuccess(parser, "1", new DeletePersonCommand(INDEX_FIRST));
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/person/EditPersonCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/person/EditPersonCommandParserTest.java
@@ -24,9 +24,9 @@ import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSucces
 import static seedu.address.logic.parser.person.PersonCliSyntax.PREFIX_PERSON_EMAIL;
 import static seedu.address.logic.parser.person.PersonCliSyntax.PREFIX_PERSON_PHONE;
 import static seedu.address.logic.parser.person.PersonCliSyntax.PREFIX_PERSON_TAG;
-import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
-import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
-import static seedu.address.testutil.TypicalIndexes.INDEX_THIRD_PERSON;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST;
+import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND;
+import static seedu.address.testutil.TypicalIndexes.INDEX_THIRD;
 
 import org.junit.jupiter.api.Test;
 
@@ -99,7 +99,7 @@ public class EditPersonCommandParserTest {
 
     @Test
     public void parse_allFieldsSpecified_success() {
-        Index targetIndex = INDEX_SECOND_PERSON;
+        Index targetIndex = INDEX_SECOND;
         String userInput = targetIndex.getOneBased() + PHONE_DESC_BOB + TAG_DESC_HUSBAND
                 + EMAIL_DESC_AMY + NAME_DESC_AMY + TAG_DESC_FRIEND;
 
@@ -113,7 +113,7 @@ public class EditPersonCommandParserTest {
 
     @Test
     public void parse_someFieldsSpecified_success() {
-        Index targetIndex = INDEX_FIRST_PERSON;
+        Index targetIndex = INDEX_FIRST;
         String userInput = targetIndex.getOneBased() + PHONE_DESC_BOB + EMAIL_DESC_AMY;
 
         EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder().withPhone(VALID_PHONE_BOB)
@@ -126,7 +126,7 @@ public class EditPersonCommandParserTest {
     @Test
     public void parse_oneFieldSpecified_success() {
         // name
-        Index targetIndex = INDEX_THIRD_PERSON;
+        Index targetIndex = INDEX_THIRD;
         String userInput = targetIndex.getOneBased() + NAME_DESC_AMY;
         EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder().withName(VALID_NAME_AMY).build();
         EditPersonCommand expectedCommand = new EditPersonCommand(targetIndex, descriptor);
@@ -157,7 +157,7 @@ public class EditPersonCommandParserTest {
         // AddCommandParserTest#parse_repeatedNonTagValue_failure()
 
         // valid followed by invalid
-        Index targetIndex = INDEX_FIRST_PERSON;
+        Index targetIndex = INDEX_FIRST;
         String userInput = targetIndex.getOneBased() + INVALID_PHONE_DESC + PHONE_DESC_BOB;
 
         assertParseFailure(parser, userInput, Messages.getErrorMessageForDuplicatePrefixes(PREFIX_PERSON_PHONE));
@@ -185,7 +185,7 @@ public class EditPersonCommandParserTest {
 
     @Test
     public void parse_resetTags_success() {
-        Index targetIndex = INDEX_THIRD_PERSON;
+        Index targetIndex = INDEX_THIRD;
         String userInput = targetIndex.getOneBased() + TAG_EMPTY;
 
         EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder().withTags().build();

--- a/src/test/java/seedu/address/logic/parser/person/PersonParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/person/PersonParserTest.java
@@ -3,7 +3,7 @@ package seedu.address.logic.parser.person;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.parser.CliSyntax.PERSON_COMMAND_WORD;
-import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST;
 
 import java.util.Arrays;
 import java.util.List;
@@ -48,8 +48,8 @@ public class PersonParserTest {
     public void parseCommand_delete() throws Exception {
         DeletePersonCommand command = (DeletePersonCommand) parser.parseCommand(
                 PERSON_COMMAND_WORD + " " + DeletePersonCommand.COMMAND_WORD + " "
-                        + INDEX_FIRST_PERSON.getOneBased());
-        assertEquals(new DeletePersonCommand(INDEX_FIRST_PERSON), command);
+                        + INDEX_FIRST.getOneBased());
+        assertEquals(new DeletePersonCommand(INDEX_FIRST), command);
     }
 
     @Test
@@ -59,9 +59,9 @@ public class PersonParserTest {
         EditPersonCommand command =
                 (EditPersonCommand) parser.parseCommand(PERSON_COMMAND_WORD + " "
                         + EditPersonCommand.COMMAND_WORD + " "
-                        + INDEX_FIRST_PERSON.getOneBased() + " "
+                        + INDEX_FIRST.getOneBased() + " "
                         + PersonUtil.getEditPersonDescriptorDetails(descriptor));
-        assertEquals(new EditPersonCommand(INDEX_FIRST_PERSON, descriptor), command);
+        assertEquals(new EditPersonCommand(INDEX_FIRST, descriptor), command);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/todo/AddPersonToTodoCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/todo/AddPersonToTodoCommandParserTest.java
@@ -1,0 +1,57 @@
+package seedu.address.logic.parser.todo;
+
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.TodoMessages.MESSAGE_MISSING_PERSON_INDEX;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+import static seedu.address.logic.parser.todo.TodoCliSyntax.PREFIX_LINKED_PERSON_INDEX;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST;
+import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.commands.todo.AddPersonToTodoCommand;
+
+public class AddPersonToTodoCommandParserTest {
+
+    private AddPersonToTodoCommandParser parser = new AddPersonToTodoCommandParser();
+
+    @Test
+    public void parse_validArgs1_returnsAddPersonToTodoCommand() {
+        assertParseSuccess(parser, "1 " + PREFIX_LINKED_PERSON_INDEX + "1 2",
+                new AddPersonToTodoCommand(INDEX_FIRST, List.of(INDEX_FIRST, INDEX_SECOND)));
+    }
+
+    @Test
+    public void parse_validArgs2_returnsAddPersonToTodoCommand() {
+        assertParseSuccess(parser, "1 " + PREFIX_LINKED_PERSON_INDEX + "1",
+                new AddPersonToTodoCommand(INDEX_FIRST, List.of(INDEX_FIRST)));
+    }
+
+    @Test
+    public void parse_missingPrefix_throwsParseException() {
+        assertParseFailure(parser, "1", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                AddPersonToTodoCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_noLinkedPesons_throwsParseException() {
+        assertParseFailure(parser, "1 " + PREFIX_LINKED_PERSON_INDEX, MESSAGE_MISSING_PERSON_INDEX);
+    }
+
+    @Test
+    public void parse_invalidTodoIndex_throwsParseException() {
+        assertParseFailure(parser, "a " + PREFIX_LINKED_PERSON_INDEX + "1 2",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                        AddPersonToTodoCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_invalidPersonIndex_throwsParseException() {
+        assertParseFailure(parser, "1 " + PREFIX_LINKED_PERSON_INDEX + "a 2",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                        AddPersonToTodoCommand.MESSAGE_USAGE));
+    }
+}

--- a/src/test/java/seedu/address/logic/parser/todo/AddTodoCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/todo/AddTodoCommandParserTest.java
@@ -1,0 +1,136 @@
+package seedu.address.logic.parser.todo;
+
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.commands.CommandTestUtil.PREAMBLE_NON_EMPTY;
+import static seedu.address.logic.commands.CommandTestUtil.PREAMBLE_WHITESPACE;
+import static seedu.address.logic.commands.TodoCommandTestUtil.DEADLINE_DESC_GRADING;
+import static seedu.address.logic.commands.TodoCommandTestUtil.DEADLINE_DESC_REPORT;
+import static seedu.address.logic.commands.TodoCommandTestUtil.INVALID_TODO_DEADLINE_DESC_INCORRECT_FORMAT;
+import static seedu.address.logic.commands.TodoCommandTestUtil.INVALID_TODO_DEADLINE_DESC_NOT_DATETIME;
+import static seedu.address.logic.commands.TodoCommandTestUtil.INVALID_TODO_NAME_DESC;
+import static seedu.address.logic.commands.TodoCommandTestUtil.LOCATION_DESC_GRADING;
+import static seedu.address.logic.commands.TodoCommandTestUtil.LOCATION_DESC_REPORT;
+import static seedu.address.logic.commands.TodoCommandTestUtil.NAME_DESC_GRADING;
+import static seedu.address.logic.commands.TodoCommandTestUtil.NAME_DESC_REPORT;
+import static seedu.address.logic.commands.TodoCommandTestUtil.VALID_DEADLINE_REPORT;
+import static seedu.address.logic.commands.TodoCommandTestUtil.VALID_LOCATION_REPORT;
+import static seedu.address.logic.commands.TodoCommandTestUtil.VALID_NAME_REPORT;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+import static seedu.address.logic.parser.todo.TodoCliSyntax.PREFIX_TODO_DEADLINE;
+import static seedu.address.logic.parser.todo.TodoCliSyntax.PREFIX_TODO_LOCATION;
+import static seedu.address.logic.parser.todo.TodoCliSyntax.PREFIX_TODO_NAME;
+import static seedu.address.testutil.TypicalTodos.GRADING;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.Messages;
+import seedu.address.logic.commands.todo.AddTodoCommand;
+import seedu.address.model.todo.Todo;
+import seedu.address.model.todo.TodoDeadline;
+import seedu.address.model.todo.TodoName;
+
+public class AddTodoCommandParserTest {
+    private final AddTodoCommandParser parser = new AddTodoCommandParser();
+
+    @Test
+    public void parse_allFieldsPresent_success() {
+        Todo expectedTodo = GRADING;
+
+        // whitespace only preamble
+        assertParseSuccess(parser,
+                PREAMBLE_WHITESPACE + NAME_DESC_GRADING + DEADLINE_DESC_GRADING
+                        + LOCATION_DESC_GRADING,
+                new AddTodoCommand(expectedTodo));
+    }
+
+    @Test
+    public void parse_repeatedNonTagValue_failure() {
+        String validExpectedTodoString = NAME_DESC_GRADING + DEADLINE_DESC_GRADING
+                + LOCATION_DESC_GRADING;
+
+        // multiple names
+        assertParseFailure(parser, NAME_DESC_REPORT + validExpectedTodoString,
+                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_TODO_NAME));
+
+        // multiple deadlines
+        assertParseFailure(parser, DEADLINE_DESC_REPORT + validExpectedTodoString,
+                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_TODO_DEADLINE));
+
+        // multiple locations
+        assertParseFailure(parser, LOCATION_DESC_GRADING + validExpectedTodoString,
+                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_TODO_LOCATION));
+
+        // multiple fields repeated
+        assertParseFailure(parser,
+                validExpectedTodoString + NAME_DESC_REPORT + DEADLINE_DESC_REPORT
+                        + LOCATION_DESC_GRADING + validExpectedTodoString,
+                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_TODO_NAME, PREFIX_TODO_DEADLINE,
+                        PREFIX_TODO_LOCATION));
+
+        // invalid value followed by valid value
+
+        // invalid name
+        assertParseFailure(parser, INVALID_TODO_NAME_DESC + validExpectedTodoString,
+                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_TODO_NAME));
+
+        // invalid email
+        assertParseFailure(parser, INVALID_TODO_DEADLINE_DESC_INCORRECT_FORMAT
+                        + validExpectedTodoString,
+                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_TODO_DEADLINE));
+
+        // valid value followed by invalid value
+
+        // invalid name
+        assertParseFailure(parser, validExpectedTodoString + INVALID_TODO_NAME_DESC,
+                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_TODO_NAME));
+
+        // invalid email
+        assertParseFailure(parser, validExpectedTodoString
+                        + INVALID_TODO_DEADLINE_DESC_INCORRECT_FORMAT,
+                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_TODO_DEADLINE));
+    }
+
+    @Test
+    public void parse_compulsoryFieldMissing_failure() {
+        String expectedMessage = String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                AddTodoCommand.MESSAGE_USAGE);
+
+        // missing name prefix
+        assertParseFailure(parser, LOCATION_DESC_REPORT + DEADLINE_DESC_REPORT,
+                expectedMessage);
+
+        // missing deadline prefix
+        assertParseFailure(parser, NAME_DESC_REPORT + LOCATION_DESC_REPORT,
+                expectedMessage);
+
+        // missing location prefix
+        assertParseFailure(parser, NAME_DESC_REPORT + DEADLINE_DESC_REPORT,
+                expectedMessage);
+
+        // all prefixes missing
+        assertParseFailure(parser, VALID_NAME_REPORT + VALID_LOCATION_REPORT
+                        + VALID_DEADLINE_REPORT,
+                expectedMessage);
+    }
+
+    @Test
+    public void parse_invalidValue_failure() {
+        // invalid name
+        assertParseFailure(parser, INVALID_TODO_NAME_DESC + DEADLINE_DESC_GRADING
+                + LOCATION_DESC_GRADING, TodoName.MESSAGE_CONSTRAINTS);
+
+        // invalid deadline
+        assertParseFailure(parser, NAME_DESC_GRADING + INVALID_TODO_DEADLINE_DESC_INCORRECT_FORMAT
+                + LOCATION_DESC_GRADING, TodoDeadline.MESSAGE_CONSTRAINTS);
+
+        assertParseFailure(parser, NAME_DESC_GRADING + INVALID_TODO_DEADLINE_DESC_NOT_DATETIME
+                + LOCATION_DESC_GRADING, TodoDeadline.MESSAGE_CONSTRAINTS);
+
+        // non-empty preamble
+        assertParseFailure(parser, PREAMBLE_NON_EMPTY + NAME_DESC_GRADING + DEADLINE_DESC_GRADING
+                        + LOCATION_DESC_GRADING,
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddTodoCommand.MESSAGE_USAGE));
+    }
+}
+

--- a/src/test/java/seedu/address/logic/parser/todo/DeleteTodoCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/todo/DeleteTodoCommandParserTest.java
@@ -1,8 +1,8 @@
 package seedu.address.logic.parser.todo;
 
-import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+import static seedu.address.logic.parser.ParserUtil.MESSAGE_INVALID_INDEX;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST;
 
 import org.junit.jupiter.api.Test;
@@ -20,8 +20,7 @@ public class DeleteTodoCommandParserTest {
 
     @Test
     public void parse_invalidArgs_throwsParseException() {
-        assertParseFailure(parser, "a", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
-                DeleteTodoCommand.MESSAGE_USAGE));
+        assertParseFailure(parser, "a", String.format(MESSAGE_INVALID_INDEX, "a"));
     }
 
 }

--- a/src/test/java/seedu/address/logic/parser/todo/DeleteTodoCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/todo/DeleteTodoCommandParserTest.java
@@ -1,0 +1,27 @@
+package seedu.address.logic.parser.todo;
+
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.commands.todo.DeleteTodoCommand;
+
+public class DeleteTodoCommandParserTest {
+
+    private DeleteTodoCommandParser parser = new DeleteTodoCommandParser();
+
+    @Test
+    public void parse_validArgs_returnsDeleteCommand() {
+        assertParseSuccess(parser, "1", new DeleteTodoCommand(INDEX_FIRST));
+    }
+
+    @Test
+    public void parse_invalidArgs_throwsParseException() {
+        assertParseFailure(parser, "a", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                DeleteTodoCommand.MESSAGE_USAGE));
+    }
+
+}

--- a/src/test/java/seedu/address/logic/parser/todo/DisplayTodoInfoCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/todo/DisplayTodoInfoCommandParserTest.java
@@ -1,0 +1,27 @@
+package seedu.address.logic.parser.todo;
+
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.commands.todo.DisplayTodoInformationCommand;
+
+public class DisplayTodoInfoCommandParserTest {
+
+    private DisplayTodoInfoCommandParser parser = new DisplayTodoInfoCommandParser();
+
+    @Test
+    public void parse_validArgs_returnsDeleteCommand() {
+        assertParseSuccess(parser, "1", new DisplayTodoInformationCommand(INDEX_FIRST));
+    }
+
+    @Test
+    public void parse_invalidArgs_throwsParseException() {
+        assertParseFailure(parser, "a", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                DisplayTodoInformationCommand.MESSAGE_USAGE));
+    }
+
+}

--- a/src/test/java/seedu/address/logic/parser/todo/DisplayTodoInfoCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/todo/DisplayTodoInfoCommandParserTest.java
@@ -1,8 +1,8 @@
 package seedu.address.logic.parser.todo;
 
-import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+import static seedu.address.logic.parser.ParserUtil.MESSAGE_INVALID_INDEX;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST;
 
 import org.junit.jupiter.api.Test;
@@ -20,8 +20,7 @@ public class DisplayTodoInfoCommandParserTest {
 
     @Test
     public void parse_invalidArgs_throwsParseException() {
-        assertParseFailure(parser, "a", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
-                DisplayTodoInformationCommand.MESSAGE_USAGE));
+        assertParseFailure(parser, "a", String.format(MESSAGE_INVALID_INDEX, "a"));
     }
 
 }

--- a/src/test/java/seedu/address/logic/parser/todo/MarkTodoAsDoneCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/todo/MarkTodoAsDoneCommandParserTest.java
@@ -1,0 +1,27 @@
+package seedu.address.logic.parser.todo;
+
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.commands.todo.MarkTodoAsDoneCommand;
+
+public class MarkTodoAsDoneCommandParserTest {
+
+    private MarkTodoAsDoneCommandParser parser = new MarkTodoAsDoneCommandParser();
+
+    @Test
+    public void parse_validArgs_returnsDeleteCommand() {
+        assertParseSuccess(parser, "1", new MarkTodoAsDoneCommand(INDEX_FIRST));
+    }
+
+    @Test
+    public void parse_invalidArgs_throwsParseException() {
+        assertParseFailure(parser, "a", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                MarkTodoAsDoneCommand.MESSAGE_USAGE));
+    }
+
+}

--- a/src/test/java/seedu/address/logic/parser/todo/MarkTodoAsDoneCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/todo/MarkTodoAsDoneCommandParserTest.java
@@ -1,8 +1,8 @@
 package seedu.address.logic.parser.todo;
 
-import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+import static seedu.address.logic.parser.ParserUtil.MESSAGE_INVALID_INDEX;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST;
 
 import org.junit.jupiter.api.Test;
@@ -20,8 +20,7 @@ public class MarkTodoAsDoneCommandParserTest {
 
     @Test
     public void parse_invalidArgs_throwsParseException() {
-        assertParseFailure(parser, "a", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
-                MarkTodoAsDoneCommand.MESSAGE_USAGE));
+        assertParseFailure(parser, "a", String.format(MESSAGE_INVALID_INDEX, "a"));
     }
 
 }

--- a/src/test/java/seedu/address/logic/parser/todo/MarkTodoAsNotDoneCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/todo/MarkTodoAsNotDoneCommandParserTest.java
@@ -1,8 +1,8 @@
 package seedu.address.logic.parser.todo;
 
-import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+import static seedu.address.logic.parser.ParserUtil.MESSAGE_INVALID_INDEX;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST;
 
 import org.junit.jupiter.api.Test;
@@ -20,8 +20,7 @@ public class MarkTodoAsNotDoneCommandParserTest {
 
     @Test
     public void parse_invalidArgs_throwsParseException() {
-        assertParseFailure(parser, "a", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
-                MarkTodoAsNotDoneCommand.MESSAGE_USAGE));
+        assertParseFailure(parser, "a", String.format(MESSAGE_INVALID_INDEX, "a"));
     }
 
 }

--- a/src/test/java/seedu/address/logic/parser/todo/MarkTodoAsNotDoneCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/todo/MarkTodoAsNotDoneCommandParserTest.java
@@ -1,0 +1,27 @@
+package seedu.address.logic.parser.todo;
+
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.commands.todo.MarkTodoAsNotDoneCommand;
+
+public class MarkTodoAsNotDoneCommandParserTest {
+
+    private MarkTodoAsNotDoneCommandParser parser = new MarkTodoAsNotDoneCommandParser();
+
+    @Test
+    public void parse_validArgs_returnsDeleteCommand() {
+        assertParseSuccess(parser, "1", new MarkTodoAsNotDoneCommand(INDEX_FIRST));
+    }
+
+    @Test
+    public void parse_invalidArgs_throwsParseException() {
+        assertParseFailure(parser, "a", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                MarkTodoAsNotDoneCommand.MESSAGE_USAGE));
+    }
+
+}

--- a/src/test/java/seedu/address/logic/parser/todo/RemovePersonFromTodoCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/todo/RemovePersonFromTodoCommandParserTest.java
@@ -13,35 +13,35 @@ import java.util.List;
 
 import org.junit.jupiter.api.Test;
 
-import seedu.address.logic.commands.todo.AddPersonToTodoCommand;
+import seedu.address.logic.commands.todo.RemovePersonFromTodoCommand;
 
-public class AddPersonToTodoCommandParserTest {
+public class RemovePersonFromTodoCommandParserTest {
 
-    private AddPersonToTodoCommandParser parser = new AddPersonToTodoCommandParser();
+    private RemovePersonFromTodoCommandParser parser = new RemovePersonFromTodoCommandParser();
 
     @Test
-    public void parse_validArgs1_returnsAddPersonToTodoCommand() {
+    public void parse_validArgs1_returnsRemovePersonFromTodoCommand() {
         assertParseSuccess(parser, "1 " + PREFIX_LINKED_PERSON_INDEX + "1 2",
-                new AddPersonToTodoCommand(INDEX_FIRST, List.of(INDEX_FIRST, INDEX_SECOND)));
+                new RemovePersonFromTodoCommand(INDEX_FIRST, List.of(INDEX_FIRST, INDEX_SECOND)));
     }
 
     @Test
-    public void parse_validArgs2_returnsAddPersonToTodoCommand() {
+    public void parse_validArgs2_returnsRemovePersonFromTodoCommand() {
         assertParseSuccess(parser, "1 " + PREFIX_LINKED_PERSON_INDEX + "1",
-                new AddPersonToTodoCommand(INDEX_FIRST, List.of(INDEX_FIRST)));
+                new RemovePersonFromTodoCommand(INDEX_FIRST, List.of(INDEX_FIRST)));
     }
 
     @Test
     public void parse_missingTodoIndex_throwsParseException() {
         assertParseFailure(parser, PREFIX_LINKED_PERSON_INDEX + "1 2",
                 String.format(MESSAGE_INVALID_COMMAND_FORMAT,
-                        AddPersonToTodoCommand.MESSAGE_USAGE));
+                        RemovePersonFromTodoCommand.MESSAGE_USAGE));
     }
 
     @Test
     public void parse_missingPrefix_throwsParseException() {
         assertParseFailure(parser, "1", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
-                AddPersonToTodoCommand.MESSAGE_USAGE));
+                RemovePersonFromTodoCommand.MESSAGE_USAGE));
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/todo/TodoParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/todo/TodoParserTest.java
@@ -1,0 +1,72 @@
+package seedu.address.logic.parser.todo;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.logic.parser.CliSyntax.TODO_COMMAND_WORD;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.commands.todo.AddTodoCommand;
+import seedu.address.logic.commands.todo.DeleteTodoCommand;
+import seedu.address.logic.commands.todo.DisplayTodoInformationCommand;
+import seedu.address.logic.commands.todo.ListTodoCommand;
+import seedu.address.logic.commands.todo.MarkTodoAsDoneCommand;
+import seedu.address.logic.commands.todo.MarkTodoAsNotDoneCommand;
+import seedu.address.logic.parser.ParserImpl;
+import seedu.address.model.todo.Todo;
+import seedu.address.testutil.TodoBuilder;
+import seedu.address.testutil.TodoUtil;
+
+public class TodoParserTest {
+
+    private final ParserImpl parser = new ParserImpl();
+
+    @Test
+    public void parseCommand_add() throws Exception {
+        Todo todo = new TodoBuilder().build();
+        AddTodoCommand command =
+                (AddTodoCommand) parser.parseCommand(TodoUtil.getAddCommand(todo));
+        assertEquals(new AddTodoCommand(todo), command);
+    }
+
+    @Test
+    public void parseCommand_delete() throws Exception {
+        DeleteTodoCommand command = (DeleteTodoCommand) parser.parseCommand(
+                TODO_COMMAND_WORD + " " + DeleteTodoCommand.COMMAND_WORD + " "
+                        + INDEX_FIRST.getOneBased());
+        assertEquals(new DeleteTodoCommand(INDEX_FIRST), command);
+    }
+
+    @Test
+    public void parseCommand_displayInfo() throws Exception {
+        DisplayTodoInformationCommand command = (DisplayTodoInformationCommand) parser.parseCommand(
+                TODO_COMMAND_WORD + " " + DisplayTodoInformationCommand.COMMAND_WORD + " "
+                        + INDEX_FIRST.getOneBased());
+        assertEquals(new DisplayTodoInformationCommand(INDEX_FIRST), command);
+    }
+
+    @Test
+    public void parseCommand_markAsDone() throws Exception {
+        MarkTodoAsDoneCommand command = (MarkTodoAsDoneCommand) parser.parseCommand(
+                TODO_COMMAND_WORD + " " + MarkTodoAsDoneCommand.COMMAND_WORD + " "
+                        + INDEX_FIRST.getOneBased());
+        assertEquals(new MarkTodoAsDoneCommand(INDEX_FIRST), command);
+    }
+
+    @Test
+    public void parseCommand_markAsNotDone() throws Exception {
+        MarkTodoAsNotDoneCommand command = (MarkTodoAsNotDoneCommand) parser.parseCommand(
+                TODO_COMMAND_WORD + " " + MarkTodoAsNotDoneCommand.COMMAND_WORD + " "
+                        + INDEX_FIRST.getOneBased());
+        assertEquals(new MarkTodoAsNotDoneCommand(INDEX_FIRST), command);
+    }
+
+    @Test
+    public void parseCommand_list() throws Exception {
+        assertTrue(parser.parseCommand(TODO_COMMAND_WORD + " "
+                + ListTodoCommand.COMMAND_WORD) instanceof ListTodoCommand);
+        assertTrue(parser.parseCommand(TODO_COMMAND_WORD + " "
+                + ListTodoCommand.COMMAND_WORD + " 3") instanceof ListTodoCommand);
+    }
+}

--- a/src/test/java/seedu/address/logic/parser/todo/TodoParserUtilTest.java
+++ b/src/test/java/seedu/address/logic/parser/todo/TodoParserUtilTest.java
@@ -1,0 +1,95 @@
+package seedu.address.logic.parser.todo;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static seedu.address.testutil.Assert.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.todo.TodoDeadline;
+import seedu.address.model.todo.TodoLocation;
+import seedu.address.model.todo.TodoName;
+
+public class TodoParserUtilTest {
+    private static final String INVALID_NAME = "Meeting with R@chel Walker";
+    private static final String INVALID_DEADLINE_NOT_DATETIME = "example";
+    private static final String INVALID_DEADLINE_INCORRECT_FORMAT = "21:20 25-12-31";
+    private static final String INVALID_DEADLINE_INVALID_DATETIME = "25-02-30 23:59";
+
+    private static final String VALID_NAME = "Meeting with Rachel Walker";
+    private static final String VALID_LOCATION = "NUS Science";
+    private static final String VALID_DEADLINE = "25-12-30 23:59";
+
+    private static final String WHITESPACE = " \t\r\n";
+
+    @Test
+    public void parseName_null_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> TodoParserUtil.parseName((String) null));
+    }
+
+    @Test
+    public void parseName_invalidValue_throwsParseException() {
+        assertThrows(ParseException.class, () -> TodoParserUtil.parseName(INVALID_NAME));
+    }
+
+    @Test
+    public void parseName_validValueWithoutWhitespace_returnsName() throws Exception {
+        TodoName expectedName = new TodoName(VALID_NAME);
+        assertEquals(expectedName, TodoParserUtil.parseName(VALID_NAME));
+    }
+
+    @Test
+    public void parseName_validValueWithWhitespace_returnsTrimmedName() throws Exception {
+        String nameWithWhitespace = WHITESPACE + VALID_NAME + WHITESPACE;
+        TodoName expectedName = new TodoName(VALID_NAME);
+        assertEquals(expectedName, TodoParserUtil.parseName(nameWithWhitespace));
+    }
+
+    @Test
+    public void parseDeadline_null_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> TodoParserUtil.parseDeadline((String) null));
+    }
+
+    @Test
+    public void parseDeadline_invalidValue_throwsParseException() {
+        assertThrows(ParseException.class, ()
+                -> TodoParserUtil.parseDeadline(INVALID_DEADLINE_INCORRECT_FORMAT));
+
+        assertThrows(ParseException.class, ()
+                -> TodoParserUtil.parseDeadline(INVALID_DEADLINE_NOT_DATETIME));
+
+        assertThrows(ParseException.class, ()
+                -> TodoParserUtil.parseDeadline(INVALID_DEADLINE_INVALID_DATETIME));
+    }
+
+    @Test
+    public void parseDeadline_validValueWithoutWhitespace_returnsDeadline() throws Exception {
+        TodoDeadline expectedDeadline = new TodoDeadline(VALID_DEADLINE);
+        assertEquals(expectedDeadline, TodoParserUtil.parseDeadline(VALID_DEADLINE));
+    }
+
+    @Test
+    public void parseDeadline_validValueWithWhitespace_returnsTrimmedDeadline() throws Exception {
+        String deadlineWithWhitespace = WHITESPACE + VALID_DEADLINE + WHITESPACE;
+        TodoDeadline expectedDeadline = new TodoDeadline(VALID_DEADLINE);
+        assertEquals(expectedDeadline, TodoParserUtil.parseDeadline(deadlineWithWhitespace));
+    }
+
+    @Test
+    public void parseLocation_null_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> TodoParserUtil.parseLocation((String) null));
+    }
+
+    @Test
+    public void parseLocation_validValueWithoutWhitespace_returnsDeadline() throws Exception {
+        TodoLocation expectedLocation = new TodoLocation(VALID_LOCATION);
+        assertEquals(expectedLocation, TodoParserUtil.parseLocation(VALID_LOCATION));
+    }
+
+    @Test
+    public void parseLocation_validValueWithWhitespace_returnsTrimmedLocation() throws Exception {
+        String locationWithWhitespace = WHITESPACE + VALID_LOCATION + WHITESPACE;
+        TodoLocation expectedLocation = new TodoLocation(VALID_LOCATION);
+        assertEquals(expectedLocation, TodoParserUtil.parseLocation(locationWithWhitespace));
+    }
+}

--- a/src/test/java/seedu/address/testutil/TodoBuilder.java
+++ b/src/test/java/seedu/address/testutil/TodoBuilder.java
@@ -1,0 +1,96 @@
+package seedu.address.testutil;
+
+import java.util.List;
+
+import seedu.address.model.person.Person;
+import seedu.address.model.todo.Todo;
+import seedu.address.model.todo.TodoDeadline;
+import seedu.address.model.todo.TodoLocation;
+import seedu.address.model.todo.TodoName;
+import seedu.address.model.todo.TodoStatus;
+
+/**
+ * A utility class to help with building Todo objects.
+ */
+public class TodoBuilder {
+
+    public static final String DEFAULT_NAME = "Todo stuff";
+    public static final String DEFAULT_DEADLINE = "25-12-31 23:59";
+    public static final String DEFAULT_LOCATION = "EARTH";
+    public static final boolean DEFAULT_STATUS = false;
+    public static final List<Person> DEFAULT_PERSONS = List.of();
+
+    private TodoName name;
+    private TodoDeadline deadline;
+    private TodoLocation location;
+    private TodoStatus status;
+    private List<Person> persons;
+
+
+    /**
+     * Creates a {@code TodoBuilder} with the default details.
+     */
+    public TodoBuilder() {
+        name = new TodoName(DEFAULT_NAME);
+        deadline = new TodoDeadline(DEFAULT_DEADLINE);
+        location = new TodoLocation(DEFAULT_LOCATION);
+        status = new TodoStatus(DEFAULT_STATUS);
+        persons = List.copyOf(DEFAULT_PERSONS);
+    }
+
+    /**
+     * Initializes the TodoBuilder with the data of {@code todoToCopy}.
+     */
+    public TodoBuilder(Todo todoToCopy) {
+        name = todoToCopy.getName();
+        deadline = todoToCopy.getDeadline();
+        location = todoToCopy.getLocation();
+        status = todoToCopy.getStatus();
+        persons = List.copyOf(todoToCopy.getPersons());
+    }
+
+    /**
+     * Sets the {@code TodoName} of the {@code Todo} that we are building.
+     */
+    public TodoBuilder withName(String name) {
+        this.name = new TodoName(name);
+        return this;
+    }
+
+    /**
+     * Sets the {@code TodoLocation} of the {@code Todo} that we are building.
+     */
+    public TodoBuilder withLocation(String location) {
+        this.location = new TodoLocation(location);
+        return this;
+    }
+
+    /**
+     * Sets the {@code TodoDeadline} of the {@code Todo} that we are building.
+     */
+    public TodoBuilder withDeadline(String deadline) {
+        this.deadline = new TodoDeadline(deadline);
+        return this;
+    }
+
+    /**
+     * Sets the {@code TodoStatus} of the {@code Todo} that we are building.
+     */
+    public TodoBuilder withStatus(boolean status) {
+        this.status = new TodoStatus(status);
+        return this;
+    }
+
+    /**
+     * Sets the {@code List<Person>} of the {@code Todo} that we are building.
+     */
+    public TodoBuilder withPersons(List<Person> persons) {
+        this.persons = List.copyOf(persons);
+        return this;
+    }
+
+    public Todo build() {
+        return new Todo(name, deadline, location, status, persons);
+    }
+
+}

--- a/src/test/java/seedu/address/testutil/TodoUtil.java
+++ b/src/test/java/seedu/address/testutil/TodoUtil.java
@@ -1,0 +1,32 @@
+package seedu.address.testutil;
+
+import static seedu.address.logic.parser.CliSyntax.TODO_COMMAND_WORD;
+import static seedu.address.logic.parser.todo.TodoCliSyntax.PREFIX_TODO_DEADLINE;
+import static seedu.address.logic.parser.todo.TodoCliSyntax.PREFIX_TODO_LOCATION;
+import static seedu.address.logic.parser.todo.TodoCliSyntax.PREFIX_TODO_NAME;
+
+import seedu.address.logic.commands.todo.AddTodoCommand;
+import seedu.address.model.todo.Todo;
+
+/**
+ * A utility class for Todo.
+ */
+public class TodoUtil {
+
+    /**
+     * Returns an add command string for adding the {@code todo}.
+     */
+    public static String getAddCommand(Todo todo) {
+        return TODO_COMMAND_WORD + " " + AddTodoCommand.COMMAND_WORD + " " + getTodoDetails(todo);
+    }
+
+    /**
+     * Returns the part of command string for the given {@code todo}'s details.
+     */
+    public static String getTodoDetails(Todo todo) {
+        String sb = PREFIX_TODO_NAME + todo.getName().name + " "
+                + PREFIX_TODO_DEADLINE + todo.getDeadline().toString() + " "
+                + PREFIX_TODO_LOCATION + todo.getLocation().value + " ";
+        return sb;
+    }
+}

--- a/src/test/java/seedu/address/testutil/TypicalIndexes.java
+++ b/src/test/java/seedu/address/testutil/TypicalIndexes.java
@@ -6,7 +6,7 @@ import seedu.address.commons.core.index.Index;
  * A utility class containing a list of {@code Index} objects to be used in tests.
  */
 public class TypicalIndexes {
-    public static final Index INDEX_FIRST_PERSON = Index.fromOneBased(1);
-    public static final Index INDEX_SECOND_PERSON = Index.fromOneBased(2);
-    public static final Index INDEX_THIRD_PERSON = Index.fromOneBased(3);
+    public static final Index INDEX_FIRST = Index.fromOneBased(1);
+    public static final Index INDEX_SECOND = Index.fromOneBased(2);
+    public static final Index INDEX_THIRD = Index.fromOneBased(3);
 }

--- a/src/test/java/seedu/address/testutil/TypicalTodos.java
+++ b/src/test/java/seedu/address/testutil/TypicalTodos.java
@@ -1,0 +1,23 @@
+package seedu.address.testutil;
+
+import static seedu.address.logic.commands.TodoCommandTestUtil.VALID_DEADLINE_GRADING;
+import static seedu.address.logic.commands.TodoCommandTestUtil.VALID_LOCATION_GRADING;
+import static seedu.address.logic.commands.TodoCommandTestUtil.VALID_LOCATION_REPORT;
+import static seedu.address.logic.commands.TodoCommandTestUtil.VALID_NAME_GRADING;
+import static seedu.address.logic.commands.TodoCommandTestUtil.VALID_NAME_REPORT;
+
+import seedu.address.model.todo.Todo;
+
+/**
+ * A utility class containing a list of {@code Todo} objects to be used in tests.
+ */
+public class TypicalTodos {
+    public static final Todo GRADING = new TodoBuilder()
+            .withName(VALID_NAME_GRADING)
+            .withDeadline(VALID_DEADLINE_GRADING)
+            .withLocation(VALID_LOCATION_GRADING).build();
+    public static final Todo REPORT = new TodoBuilder()
+            .withName(VALID_NAME_REPORT)
+            .withDeadline(VALID_DEADLINE_GRADING)
+            .withLocation(VALID_LOCATION_REPORT).build();
+}


### PR DESCRIPTION
Resolves #155 

Also fixes a few things along the way:

- Moves all `DateTimeFormatter`s into a `DatetimeUtil` class and resolves #156 
- Fixes an inconsistency related to error messages on invalid indices in todo command parsers. Previously, if the invalid index was in the preamble of the command, then the usage message was displayed. However, if it was after a prefix of the command, the message `Index is not a non-zero unsigned integer` was displayed. Resolves by displaying `Index is not a non-zero unsigned integer: <invalid_index>` in all cases.